### PR TITLE
Add README section for VS Code and extract common parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,25 +63,33 @@ Save the config file and restart Claude Desktop. If everything is set up correct
 
 Follow the [official guide](https://code.visualstudio.com/blogs/2025/04/07/agentMode) to enable Agent mode in Copilot Chat.
 
-Then, open VSCode's `settings.json`, and add the Bitrise MCP server configuration under the `mcp.servers` key:
+Then, open VSCode's `settings.json` (either the workspace level or the user level settings), and add the Bitrise MCP server configuration under the `mcp.servers` key, and the workspace token input under the `mcp.inputs` key:
 
 ```json
 {
   "mcp": {
-      "servers": {
-          "bitrise": {
-              "command": "uvx",
-              "args": [
-                  "--from",
-                  "git+https://github.com/bitrise-io/bitrise-mcp@v1.0.1",
-                  "bitrise-mcp"
-              ],
-              "type": "stdio",
-              "env": {
-                  "BITRISE_TOKEN": "<YOUR_TOKEN>"
-              },
-          },
+    "inputs": [
+      {
+        "id": "bitrise-workspace-token",
+        "type": "promptString",
+        "description": "Bitrise workspace token",
+        "password": true
       }
+    ],
+    "servers": {
+      "bitrise": {
+        "command": "uvx",
+        "args": [
+          "--from",
+          "git+https://github.com/bitrise-io/bitrise-mcp@v1.0.1",
+          "bitrise-mcp"
+        ],
+        "type": "stdio",
+        "env": {
+          "BITRISE_TOKEN": "${input:bitrise-workspace-token}"
+        }
+      },
+    }
   }
 }
 ```
@@ -101,7 +109,7 @@ Example configuration:
     "bitrise": {
       "command": "uvx",
       "env": {
-        "BITRISE_TOKEN": "<YOUR_PAT>"
+        "BITRISE_TOKEN": "${input:bitrise-workspace-token}"
       },
       "args": [
         "--from",
@@ -110,7 +118,7 @@ Example configuration:
         "--enabled-api-groups",
         "cache-items,pipelines"
       ]
-    }
+    },
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -59,6 +59,37 @@ Click _Edit config_. This creates a config file called `claude_desktop_config.js
 
 Save the config file and restart Claude Desktop. If everything is set up correctly, you should see a hammer icon next to the message composer.
 
+### Use with [VS Code](https://code.visualstudio.com/Download)
+
+Follow the [official guide](https://code.visualstudio.com/blogs/2025/04/07/agentMode) to enable Agent mode in Copilot Chat.
+
+Then, open VSCode's `settings.json`, and add the Bitrise MCP server configuration under the `mcp.servers` key:
+
+```json
+{
+  "mcp": {
+      "servers": {
+          "bitrise": {
+              "command": "uvx",
+              "args": [
+                  "--from",
+                  "git+https://github.com/bitrise-io/bitrise-mcp@v1.0.1",
+                  "bitrise-mcp"
+              ],
+              "type": "stdio",
+              "env": {
+                  "BITRISE_TOKEN": "<YOUR_TOKEN>"
+              },
+          },
+      }
+  }
+}
+```
+
+Save the configuration. VS Code will automatically recognize the change and load the tools into Copilot Chat.
+
+### Advanced configuration
+
 You can limit the number of tools exposed to the MCP client. This is useful if you want to optimize token usage or your MCP client has a limit on the number of tools.
 
 Tools are grouped by their "API group", and you can pass the groups you want to expose as tools. Possible values: `apps, builds, workspaces, webhooks, build-artifacts, group-roles, cache-items, pipelines, account, read-only`.
@@ -68,7 +99,7 @@ Example configuration:
 {
   "mcpServers": {
     "bitrise": {
-      "command": "<ABSOLUTE_PATH_TO>/uvx",
+      "command": "uvx",
       "env": {
         "BITRISE_TOKEN": "<YOUR_PAT>"
       },

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Example configuration:
     "bitrise": {
       "command": "uvx",
       "env": {
-        "BITRISE_TOKEN": "${input:bitrise-workspace-token}"
+        "BITRISE_TOKEN": "<YOUR_PAT>"
       },
       "args": [
         "--from",


### PR DESCRIPTION
VS Code now has first class support, MCP servers can be restarted and separately monitored, and enabled/disabled per tool.
![image](https://github.com/user-attachments/assets/2b3abe4f-f4b2-479e-904b-6210871cfa72)
![image](https://github.com/user-attachments/assets/a19596d9-a297-4e01-9b84-f8e3b3719896)


