### PR TITLE
Release management api_group with endpoints as mcp_tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ You can limit the number of tools exposed to the MCP client. This is useful if y
 
 Tools are grouped by their "API group", and you can pass the groups you want to expose as tools. Possible values: `apps, builds, workspaces, webhooks, build-artifacts, group-roles, cache-items, pipelines, account, read-only, release-management`.
 
+We recommend using the `release-management` API group separately to avoid any confusion with the `apps` API group.
+
 Example configuration:
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Save the config file and restart Claude Desktop. If everything is set up correct
 
 You can limit the number of tools exposed to the MCP client. This is useful if you want to optimize token usage or your MCP client has a limit on the number of tools.
 
-Tools are grouped by their "API group", and you can pass the groups you want to expose as tools. Possible values: `apps, builds, workspaces, webhooks, build-artifacts, group-roles, cache-items, pipelines, account, read-only`.
+Tools are grouped by their "API group", and you can pass the groups you want to expose as tools. Possible values: `apps, builds, workspaces, webhooks, build-artifacts, group-roles, cache-items, pipelines, account, read-only, release-management`.
 
 Example configuration:
 ```json
@@ -383,55 +383,219 @@ Example configuration:
 44. `me`
     - Get info from the currently authenticated user account
 
+### Release Management
+
+# MCP Tools
+
+45. `create_connected_app`
+   - Add a new Release Management connected app to Bitrise.
+   - Arguments:
+     - `platform`: The mobile platform for the connected app (ios/android).
+     - `store_app_id`: The app store identifier for the connected app.
+     - `workspace_slug`: Identifier of the Bitrise workspace.
+     - `id`: (Optional) An uuidV4 identifier for your new connected app.
+     - `manual_connection`: (Optional) Indicates a manual connection.
+     - `project_id`: (Optional) Specifies which Bitrise Project to associate with.
+     - `store_app_name`: (Optional) App name for manual connections.
+     - `store_credential_id`: (Optional) Selection of credentials added on Bitrise.
+
+46. `list_connected_apps`
+   - List Release Management connected apps available for the authenticated account within a workspace.
+   - Arguments:
+     - `workspace_slug`: Identifier of the Bitrise workspace.
+     - `items_per_page`: (Optional) Maximum number of connected apps per page.
+     - `page`: (Optional) Page number to return.
+     - `platform`: (Optional) Filter for a specific mobile platform.
+     - `project_id`: (Optional) Filter for a specific Bitrise Project.
+     - `search`: (Optional) Search by bundle ID, package name, or app title.
+
+47. `get_connected_app`
+   - Gives back a Release Management connected app for the authenticated account.
+   - Arguments:
+     - `id`: Identifier of the Release Management connected app.
+
+48. `update_connected_app`
+   - Updates a connected app.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier for your connected app.
+     - `store_app_id`: The store identifier for your app.
+     - `connect_to_store`: (Optional) Check validity against the App Store or Google Play.
+     - `store_credential_id`: (Optional) Selection of credentials added on Bitrise.
+
+49. `list_installable_artifacts`
+   - List Release Management installable artifacts of a connected app.
+   - Arguments:
+     - `connected_app_id`: Identifier of the Release Management connected app.
+     - `after_date`: (Optional) Start of the interval for artifact creation/upload.
+     - `artifact_type`: (Optional) Filter for a specific artifact type.
+     - `before_date`: (Optional) End of the interval for artifact creation/upload.
+     - `branch`: (Optional) Filter for the Bitrise CI branch.
+     - `distribution_ready`: (Optional) Filter for distribution ready artifacts.
+     - `items_per_page`: (Optional) Maximum number of artifacts per page.
+     - `page`: (Optional) Page number to return.
+     - `platform`: (Optional) Filter for a specific mobile platform.
+     - `search`: (Optional) Search by version, filename or build number.
+     - `source`: (Optional) Filter for the source of installable artifacts.
+     - `store_signed`: (Optional) Filter for store ready installable artifacts.
+     - `version`: (Optional) Filter for a specific version.
+     - `workflow`: (Optional) Filter for a specific Bitrise CI workflow.
+
+50. `generate_installable_artifact_upload_url`
+   - Generates a signed upload URL for an installable artifact to be uploaded to Bitrise.
+   - Arguments:
+     - `connected_app_id`: Identifier of the Release Management connected app.
+     - `installable_artifact_id`: An uuidv4 identifier for the installable artifact.
+     - `file_name`: The name of the installable artifact file.
+     - `file_size_bytes`: The byte size of the installable artifact file.
+     - `branch`: (Optional) Name of the CI branch.
+     - `with_public_page`: (Optional) Enable public install page.
+     - `workflow`: (Optional) Name of the CI workflow.
+
+51. `get_installable_artifact_upload_and_processing_status`
+   - Gets the processing and upload status of an installable artifact.
+   - Arguments:
+     - `connected_app_id`: Identifier of the Release Management connected app.
+     - `installable_artifact_id`: The uuidv4 identifier for the installable artifact.
+
+52. `set_installable_artifact_public_install_page`
+   - Changes whether public install page should be available for the installable artifact.
+   - Arguments:
+     - `connected_app_id`: Identifier of the Release Management connected app.
+     - `installable_artifact_id`: The uuidv4 identifier for the installable artifact.
+     - `with_public_page`: Boolean flag for enabling/disabling public install page.
+
+53. `list_build_distribution_versions`
+   - Lists Build Distribution versions available for testers.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `items_per_page`: (Optional) Maximum number of versions per page.
+     - `page`: (Optional) Page number to return.
+
+54. `list_build_distribution_version_test_builds`
+   - Gives back a list of test builds for the given build distribution version.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `version`: The version of the build distribution.
+     - `items_per_page`: (Optional) Maximum number of test builds per page.
+     - `page`: (Optional) Page number to return.
+
+55. `create_tester_group`
+   - Creates a tester group for a Release Management connected app.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `name`: The name for the new tester group.
+     - `auto_notify`: (Optional) Indicates automatic notifications for the group.
+
+56. `notify_tester_group`
+   - Notifies a tester group about a new test build.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `id`: The uuidV4 identifier of the tester group.
+     - `test_build_id`: The unique identifier of the test build.
+
+57. `add_testers_to_tester_group`
+   - Adds testers to a tester group of a connected app.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `id`: The uuidV4 identifier of the tester group.
+     - `user_slugs`: The list of users identified by slugs to be added.
+
+58. `update_tester_group`
+   - Updates the given tester group settings.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `id`: The uuidV4 identifier of the tester group.
+     - `auto_notify`: (Optional) Setting for automatic email notifications.
+     - `name`: (Optional) The new name for the tester group.
+
+59. `list_tester_groups`
+   - Gives back a list of tester groups related to a specific connected app.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `items_per_page`: (Optional) Maximum number of tester groups per page.
+     - `page`: (Optional) Page number to return.
+
+60. `get_tester_group`
+   - Gives back the details of the selected tester group.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `id`: The uuidV4 identifier of the tester group.
+
+61. `get_potential_testers`
+   - Gets a list of potential testers who can be added to a specific tester group.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `id`: The uuidV4 identifier of the tester group.
+     - `items_per_page`: (Optional) Maximum number of potential testers per page.
+     - `page`: (Optional) Page number to return.
+     - `search`: (Optional) Search for testers by email or username.
+
 ## API Groups
 
 The Bitrise MCP server organizes tools into API groups that can be enabled or disabled via command-line arguments. The table below shows which API groups each tool belongs to:
 
-| Tool | apps | builds | workspaces | webhooks | build-artifacts | group-roles | cache-items | pipelines | account | read-only |
-|------|------|--------|------------|----------|----------------|-------------|-------------|-----------|---------|-----------|
-| list_apps | ✅ | | | | | | | | | ✅ |
-| register_app | ✅ | | | | | | | | | |
-| finish_bitrise_app | ✅ | | | | | | | | | |
-| get_app | ✅ | | | | | | | | | ✅ |
-| delete_app | ✅ | | | | | | | | | |
-| update_app | ✅ | | | | | | | | | |
-| get_bitrise_yml | ✅ | | | | | | | | | ✅ |
-| update_bitrise_yml | ✅ | | | | | | | | | |
-| list_branches | ✅ | | | | | | | | | ✅ |
-| register_ssh_key | ✅ | | | | | | | | | |
-| register_webhook | ✅ | | | | | | | | | |
-| list_builds | | ✅ | | | | | | | | ✅ |
-| trigger_bitrise_build | | ✅ | | | | | | | | |
-| get_build | | ✅ | | | | | | | | ✅ |
-| abort_build | | ✅ | | | | | | | | |
-| get_build_log | | ✅ | | | | | | | | ✅ |
-| get_build_bitrise_yml | | ✅ | | | | | | | | ✅ |
-| list_build_workflows | | ✅ | | | | | | | | ✅ |
-| list_artifacts | | | | | ✅ | | | | | ✅ |
-| get_artifact | | | | | ✅ | | | | | ✅ |
-| delete_artifact | | | | | ✅ | | | | | |
-| update_artifact | | | | | ✅ | | | | | |
-| list_outgoing_webhooks | | | | ✅ | | | | | | ✅ |
-| delete_outgoing_webhook | | | | ✅ | | | | | | |
-| update_outgoing_webhook | | | | ✅ | | | | | | |
-| create_outgoing_webhook | | | | ✅ | | | | | | |
-| list_cache_items | | | | | | | ✅ | | | ✅ |
-| delete_all_cache_items | | | | | | | ✅ | | | |
-| delete_cache_item | | | | | | | ✅ | | | |
-| get_cache_item_download_url | | | | | | | ✅ | | | ✅ |
-| list_pipelines | | | | | | | | ✅ | | ✅ |
-| get_pipeline | | | | | | | | ✅ | | ✅ |
-| abort_pipeline | | | | | | | | ✅ | | |
-| rebuild_pipeline | | | | | | | | ✅ | | |
-| list_group_roles | | | | | | ✅ | | | | ✅ |
-| replace_group_roles | | | | | | ✅ | | | | |
-| list_workspaces | | | ✅ | | | | | | | ✅ |
-| get_workspace | | | ✅ | | | | | | | ✅ |
-| get_workspace_groups | | | ✅ | | | | | | | ✅ |
-| create_workspace_group | | | ✅ | | | | | | | |
-| get_workspace_members | | | ✅ | | | | | | | ✅ |
-| invite_member_to_workspace | | | ✅ | | | | | | | |
-| add_member_to_group | | | ✅ | | | | | | | |
-| me | | | | | | | | | ✅ | ✅ |
+| Tool | apps | builds | workspaces | webhooks | build-artifacts | group-roles | cache-items | pipelines | account | read-only | release-management |
+|------|------|--------|------------|----------|----------------|-------------|-------------|-----------|---------|-----------|-------------------|
+| list_apps | ✅ | | | | | | | | | ✅ | |
+| register_app | ✅ | | | | | | | | | | |
+| finish_bitrise_app | ✅ | | | | | | | | | | |
+| get_app | ✅ | | | | | | | | | ✅ | |
+| delete_app | ✅ | | | | | | | | | | |
+| update_app | ✅ | | | | | | | | | | |
+| get_bitrise_yml | ✅ | | | | | | | | | ✅ | |
+| update_bitrise_yml | ✅ | | | | | | | | | | |
+| list_branches | ✅ | | | | | | | | | ✅ | |
+| register_ssh_key | ✅ | | | | | | | | | | |
+| register_webhook | ✅ | | | | | | | | | | |
+| list_builds | | ✅ | | | | | | | | ✅ | |
+| trigger_bitrise_build | | ✅ | | | | | | | | | |
+| get_build | | ✅ | | | | | | | | ✅ | |
+| abort_build | | ✅ | | | | | | | | | |
+| get_build_log | | ✅ | | | | | | | | ✅ | |
+| get_build_bitrise_yml | | ✅ | | | | | | | | ✅ | |
+| list_build_workflows | | ✅ | | | | | | | | ✅ | |
+| list_artifacts | | | | | ✅ | | | | | ✅ | |
+| get_artifact | | | | | ✅ | | | | | ✅ | |
+| delete_artifact | | | | | ✅ | | | | | | |
+| update_artifact | | | | | ✅ | | | | | | |
+| list_outgoing_webhooks | | | | ✅ | | | | | | ✅ | |
+| delete_outgoing_webhook | | | | ✅ | | | | | | | |
+| update_outgoing_webhook | | | | ✅ | | | | | | | |
+| create_outgoing_webhook | | | | ✅ | | | | | | | |
+| list_cache_items | | | | | | | ✅ | | | ✅ | |
+| delete_all_cache_items | | | | | | | ✅ | | | | |
+| delete_cache_item | | | | | | | ✅ | | | | |
+| get_cache_item_download_url | | | | | | | ✅ | | | ✅ | |
+| list_pipelines | | | | | | | | ✅ | | ✅ | |
+| get_pipeline | | | | | | | | ✅ | | ✅ | |
+| abort_pipeline | | | | | | | | ✅ | | | |
+| rebuild_pipeline | | | | | | | | ✅ | | | |
+| list_group_roles | | | | | | ✅ | | | | ✅ | |
+| replace_group_roles | | | | | | ✅ | | | | | |
+| list_workspaces | | | ✅ | | | | | | | ✅ | |
+| get_workspace | | | ✅ | | | | | | | ✅ | |
+| get_workspace_groups | | | ✅ | | | | | | | ✅ | |
+| create_workspace_group | | | ✅ | | | | | | | | |
+| get_workspace_members | | | ✅ | | | | | | | ✅ | |
+| invite_member_to_workspace | | | ✅ | | | | | | | | |
+| add_member_to_group | | | ✅ | | | | | | | | |
+| me | | | | | | | | | ✅ | ✅ | |
+| create_connected_app | | | | | | | | | | | ✅ |
+| list_connected_apps | | | | | | | | | | | ✅ |
+| get_connected_app | | | | | | | | | | | ✅ |
+| update_connected_app | | | | | | | | | | | ✅ |
+| list_installable_artifacts | | | | | | | | | | | ✅ |
+| generate_installable_artifact_upload_url | | | | | | | | | | | ✅ |
+| get_installable_artifact_upload_and_processing_status | | | | | | | | | | | ✅ |
+| set_installable_artifact_public_install_page | | | | | | | | | | | ✅ |
+| list_build_distribution_versions | | | | | | | | | | | ✅ |
+| list_build_distribution_version_test_builds | | | | | | | | | | | ✅ |
+| create_tester_group | | | | | | | | | | | ✅ |
+| notify_tester_group | | | | | | | | | | | ✅ |
+| add_testers_to_tester_group | | | | | | | | | | | ✅ |
+| update_tester_group | | | | | | | | | | | ✅ |
+| list_tester_groups | | | | | | | | | | | ✅ |
+| get_tester_group | | | | | | | | | | | ✅ |
+| get_potential_testers | | | | | | | | | | | ✅ |
 
 By default, all API groups are enabled. You can specify which groups to enable using the `--enabled-api-groups` command-line argument with a comma-separated list of group names.

--- a/main.py
+++ b/main.py
@@ -54,6 +54,8 @@ async def call_api(method, url: str, body=None, params=None) -> str:
 
 
 # ===== Apps =====
+
+
 @mcp_tool(
     api_groups=["apps", "read-only"],
     description="List all the apps available for the authenticated account.",

--- a/main.py
+++ b/main.py
@@ -965,6 +965,11 @@ async def add_member_to_group(
     description="Get user info for the currently authenticated user account",
 )
 
+async def me() -> str:
+    url = f"{BITRISE_API_BASE}/me"
+    return await call_api("GET", url)
+
+
 # ===== Release Management =====
 @mcp_tool(
     api_groups=["release-management"],
@@ -1627,11 +1632,6 @@ async def get_potential_testers(
 
     url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/testers"
     return await call_api("GET", url, params=params)
-
-
-async def me() -> str:
-    url = f"{BITRISE_API_BASE}/me"
-    return await call_api("GET", url)
 
 
 def main():

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import os
 import httpx
 import sys
 from functools import partial
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 

--- a/main.py
+++ b/main.py
@@ -81,14 +81,7 @@ async def list_apps(
         params["limit"] = limit
 
     url = f"{BITRISE_API_BASE}/apps"
-    async with httpx.AsyncClient() as client:
-        headers = {
-            "User-Agent": USER_AGENT,
-            "Accept": "application/json",
-            "Authorization": os.environ.get("BITRISE_TOKEN") or "",
-        }
-        response = await client.get(url, headers=headers, params=params, timeout=30.0)
-        return response.text
+    return await call_api("GET", url, params=params)
 
 
 @mcp_tool(
@@ -971,6 +964,8 @@ async def me() -> str:
 
 
 # ===== Release Management =====
+
+
 @mcp_tool(
     api_groups=["release-management"],
     description="Add a new Release Management connected app to Bitrise."

--- a/main.py
+++ b/main.py
@@ -53,370 +53,6 @@ async def call_api(method, url: str, body=None, params=None) -> str:
         return response.text
 
 
-# ===== Release Management =====
-@mcp_tool(
-    api_groups=["release-management"],
-    description="Add a new Release Management connected app to Bitrise."
-)
-async def create_connected_app(
-    platform: str = Field(
-        description="The mobile platform for the connected app. Available values are 'ios' and 'android'.",
-    ),
-    store_app_id: str = Field(
-        description="The app store identifier for the connected app. In case of 'ios' platform it is the bundle id "
-                    "from App Store Connect. For additional context you can check the property description: "
-                    "https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier"
-                    "In case of Android platform it is the package name. Check the documentation: "
-                    "https://developer.android.com/build/configure-app-module#set_the_application_id",
-    ),
-    workspace_slug: str = Field(
-        description="Identifier of the Bitrise workspace for the Release Management connected app. This field is mandatory.",
-    ),
-    id: Optional[str] = Field(
-        default=None,
-        description="An uuidV4 identifier for your new connected app. If it is not given, one will be generated. It is "
-                    "useful for making the request idempotent or if the id is triggered outside of Bitrise and needs "
-                    "to be stored separately as well.",
-    ),
-    manual_connection: Optional[bool] = Field(
-        default=False,
-        description="If set to true it indicates a manual connection (bypassing using store api keys) and requires "
-                    "giving 'store_app_name' as well. This can be especially useful for enterprise apps.",
-    ),
-    project_id: Optional[str] = Field(
-        default=None,
-        description="Specifies which Bitrise Project you want to get the connected app to be associated with. If this field is not given a new project will be created alongside with the connected app.",
-    ),
-    store_app_name: Optional[str] = Field(
-        default=None,
-        description="If you have no active app store API keys added on Bitrise, you can decide to add your app manually by giving the app's name as well while indicating manual connection with the similarly named boolean flag.",
-    ),
-    store_credential_id: Optional[str] = Field(
-        default=None,
-        description="If you have credentials added on Bitrise, you can decide to select one for your app. In case of "
-                    "ios platform it will be an Apple API credential id. In case of android platform it will be a "
-                    "Google Service credential id.",
-    ),
-) -> str:
-    url = f"{BITRISE_RM_API_BASE}/connected-apps"
-    body = {
-        "platform": platform,
-        "store_app_id": store_app_id,
-        "workspace_slug": workspace_slug,
-        "id": id,
-        "manual_connection": manual_connection,
-        "project_id": project_id,
-        "store_app_name": store_app_name,
-        "store_credential_id": store_credential_id,
-    }
-    return await call_api("POST", url, body=body)
-
-@mcp_tool(
-    api_groups=["release-management"],
-    description="List Release Management connected apps available for the authenticated account within a workspace.",
-)
-async def list_connected_apps(
-    workspace_slug: str = Field(
-        description="Identifier of the Bitrise workspace for the Release Management connected apps. This field is mandatory.",
-    ),
-    project_id: Optional[str] = Field(
-        default=None,
-        description="Specifies which Bitrise Project you want to get associated connected apps for",
-    ),
-    platform: Optional[str] = Field(
-        default=None,
-        description="Filters for a specific mobile platform for the list of connected apps. Available values are: 'ios' and 'android'.",
-    ),
-    search: Optional[str] = Field(
-        default=None,
-        description="Search by bundle ID (for ios), package name (for android), or app title (for both platforms). The filter is case-sensitive.",
-    ),
-    items_per_page: Optional[int] = Field(
-        default=10,
-        description="Specifies the maximum number of connected apps returned per page. Default value is 10.",
-    ),
-    page: Optional[int] = Field(
-        default=1,
-        description="Specifies which page should be returned from the whole result set in a paginated scenario. Default value is 1.",
-    ),
-) -> str:
-    params: Dict[str, Union[str, int]] = {}
-    if workspace_slug:
-        params["workspace_slug"] = workspace_slug
-    if project_id:
-        params["project_id"] = project_id
-    if platform:
-        params["platform"] = platform
-    if search:
-        params["search"] = search
-    if items_per_page:
-        params["items_per_page"] = items_per_page
-    if page:
-        params["page"] = page
-
-    url = f"{BITRISE_RM_API_BASE}/connected-apps"
-    return await call_api("GET", url, params=params)
-
-@mcp_tool(
-    api_groups=["release-management"],
-    description="Gives back a Release Management connected app for the authenticated account.",
-)
-async def get_connected_app(
-    id: str = Field(
-        description="Identifier of the Release Management connected app",
-    ),
-) -> str:
-    url = f"{BITRISE_RM_API_BASE}/connected-apps/{id}"
-    return await call_api("GET", url)
-
-@mcp_tool(
-    api_groups=["release-management"],
-    description="Updates a connected app."
-)
-async def update_connected_app(
-    connected_app_id: str = Field(
-        description="The uuidV4 identifier for your connected app.",
-    ),
-    connect_to_store: Optional[bool] = Field(
-        default=False,
-        description="If true, will check connected app validity against the Apple App Store or Google Play Store "
-                    "(dependent on the platform of your connected app). This means, that the already set or just given "
-                    "store_app_id will be validated against the Store, using the already set or just given store "
-                    "credential id.",
-    ),
-    store_app_id: Optional[str] = Field(
-        description="The store identifier for your app. You can change the previously set store_app_id to match the "
-                "one in the App Store or Google Play depending on the app platform. This is especially useful if "
-                "you want to connect your app with the store as the system will validate the given store_app_id "
-                "against the Store. In case of iOS platform it is the bundle id. In case of Android platform it is "
-                "the package name.",
-    ),
-    store_credential_id: Optional[str] = Field(
-        default=None,
-        description="If you have credentials added on Bitrise, you can decide to select one for your app. In case of "
-                    "ios platform it will be an Apple API credential id. In case of android platform it will be a "
-                    "Google Service credential id.",
-    ),
-) -> str:
-    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}"
-    body = {
-        "connect_to_store": connect_to_store,
-        "store_app_id": store_app_id,
-        "store_credential_id": store_credential_id,
-    }
-    return await call_api("PATCH", url, body=body)
-
-@mcp_tool(
-    api_groups=["release-management"],
-    description="List Release Management installable artifacts of a connected app available for the authenticated account.",
-)
-async def list_installable_artifacts(
-    connected_app_id: str = Field(
-        description="Identifier of the Release Management connected app for the installable artifacts. This field is mandatory.",
-    ),
-
-    after_date: Optional[str] = Field(
-        default=None,
-        description="A date in ISO 8601 string format specifying the start of the interval when the installable "
-                    "artifact to be returned was created or uploaded. This value will be defaulted to 1 month ago if "
-                    "distribution_ready filter is not set or set to false."
-    ),
-    artifact_type: Optional[str] = Field(
-        default=None,
-        description="Filters for a specific artifact type or file extension for the list of installable artifacts. "
-                    "Available values are: 'aab' and 'apk' for android artifacts and 'ipa' for ios artifacts."
-    ),
-    before_date: Optional[str] = Field(
-        default=None,
-        description="A date in ISO 8601 string format specifying the end of the interval when the installable artifact "
-                    "to be returned was created or uploaded. This value will be defaulted to the current time if "
-                    "distribution_ready filter is not set or set to false."
-    ),
-    branch: Optional[str] = Field(
-        default=None,
-        description="Filters for the Bitrise CI branch of the installable artifact on which it has been generated on.",
-    ),
-    distribution_ready: Optional[bool] = Field(
-        default=None,
-        description="Filters for distribution ready installable artifacts. This means .apk and .ipa (with "
-                    "distribution type ad-hoc, development, or enterprise) installable artifacts.",
-    ),
-    items_per_page: Optional[int] = Field(
-        default=10,
-        description="Specifies the maximum number of installable artifacts to be returned per page. Default value is 10.",
-    ),
-    page: Optional[int] = Field(
-        default=1,
-        description="Specifies which page should be returned from the whole result set in a paginated scenario. Default value is 1.",
-    ),
-    platform: Optional[str] = Field(
-        default=None,
-        description="Filters for a specific mobile platform for the list of installable artifacts. Available values are: 'ios' and 'android'.",
-    ),
-    search: Optional[str] = Field(
-        default=None,
-        description="Search by version, filename or build number (Bitrise CI). The filter is case-sensitive.",
-    ),
-    source: Optional[str] = Field(
-        default=None,
-        description="Filters for the source of installable artifacts to be returned. Available values are 'api' and "
-                    "'ci'."
-    ),
-    store_signed: Optional[bool] = Field(
-        default=None,
-        description="Filters for store ready installable artifacts. This means signed .aab and .ipa (with distribution type app-store) installable artifacts.",
-    ),
-    version: Optional[str] = Field(
-        default=None,
-        description="Filters for the version this installable artifact was created for. This field is required if the "
-                    "distribution_ready filter is set to true."
-    ),
-    workflow: Optional[str] = Field(
-        default=None,
-        description="Filters for the Bitrise CI workflow of the installable artifact it has been generated by.",
-    ),
-) -> str:
-    params: Dict[str, Union[str, int, bool]] = {}
-    if connected_app_id:
-        params["connected_app_id"] = connected_app_id
-
-    if after_date:
-        params["after_date"] = after_date
-    if artifact_type:
-        params["artifact_type"] = artifact_type
-    if before_date:
-        params["before_date"] = before_date
-    if branch:
-        params["branch"] = branch
-    if distribution_ready:
-        params["distribution_ready"] = distribution_ready
-    if items_per_page:
-        params["items_per_page"] = items_per_page
-    if page:
-        params["page"] = page
-    if platform:
-        params["platform"] = platform
-    if search:
-        params["search"] = search
-    if source:
-        params["source"] = source
-    if store_signed:
-        params["store_signed"] = store_signed
-    if version:
-        params["version"] = version
-    if workflow:
-        params["workflow"] = workflow
-
-    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/installable-artifacts"
-    return await call_api("GET", url, params=params)
-
-@mcp_tool(
-    api_groups=["release-management"],
-    description="Generates a signed upload url valid for 1 hour for an installable artifact to be uploaded to Bitrise "
-                "Release Management. The response will contain an url that can be used to upload an artifact to Bitrise "
-                "Release Management using a simple curl request with the file data that should be uploaded. The "
-                "necessary headers and http method will also be in the response. This artifact will need to be "
-                "processed after upload to be usable. The status of processing can be checked by making another request"
-                "to a different url giving back the processed status of an installable artifact.",
-)
-async def generate_installable_artifact_upload_url(
-    connected_app_id: str = Field(
-        description="Identifier of the Release Management connected app for the installable artifact. This field is mandatory.",
-    ),
-    installable_artifact_id: str = Field(
-        description="An uuidv4 identifier generated on the client side for the installable artifact. This field is "
-                    "mandatory.",
-    ),
-
-    file_name: str = Field(
-        description="The name of the installable artifact file (with extension) to be uploaded to Bitrise. This field "
-                    "is mandatory.",
-    ),
-    file_size_bytes: str = Field(
-        description="The byte size of the installable artifact file to be uploaded.",
-    ),
-
-    branch: Optional[str] = Field(
-        default=None,
-        description="Optionally you can add the name of the CI branch the installable artifact has been generated on.",
-    ),
-    with_public_page: Optional[bool] = Field(
-        default=None,
-        description="Optionally, you can enable public install page for your artifact. This can only be enabled by "
-                    "Bitrise Project Admins, Bitrise Project Owners and Bitrise Workspace Admins. Changing this value "
-                    "without proper permissions will result in an error. The default value is false.",
-    ),
-    workflow: Optional[str] = Field(
-        default=None,
-        description="Optionally you can add the name of the CI workflow this installable artifact has been generated by.",
-    ),
-) -> str:
-    params: Dict[str, Union[str, int, bool]] = {}
-    if connected_app_id:
-        params["connected_app_id"] = connected_app_id
-    if installable_artifact_id:
-        params["installable_artifact_id"] = installable_artifact_id
-
-    if file_name:
-        params["file_name"] = file_name
-    if file_size_bytes:
-        params["file_size_bytes"] = file_size_bytes
-
-    if branch:
-        params["branch"] = branch
-    if with_public_page:
-        params["with_public_page"] = with_public_page
-    if workflow:
-        params["workflow"] = workflow
-
-    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/installable-artifacts/{installable_artifact_id}/upload-url"
-    return await call_api("GET", url, params=params)
-
-@mcp_tool(
-    api_groups=["release-management"],
-    description="Gets the processing and upload status of an installable artifact. An artifact will need to be "
-                "processed after upload to be usable. This endpoint helps understanding when an uploaded installable "
-                "artifacts becomes usable for later purposes.",
-)
-async def get_installable_artifact_upload_and_processing_status(
-    connected_app_id: str = Field(
-        description="Identifier of the Release Management connected app for the installable artifact. This field is mandatory.",
-    ),
-    installable_artifact_id: str = Field(
-        description="The uuidv4 identifier for the installable artifact. This field is mandatory.",
-    ),
-) -> str:
-    params: Dict[str, Union[str, int, bool]] = {}
-    if connected_app_id:
-        params["connected_app_id"] = connected_app_id
-    if installable_artifact_id:
-        params["installable_artifact_id"] = installable_artifact_id
-
-    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/installable-artifacts/{installable_artifact_id}/status"
-    return await call_api("GET", url, params=params)
-
-@mcp_tool(
-    api_groups=["release-management"],
-    description="Changes whether public install page should be available for the installable artifact or not."
-)
-async def set_installable_artifact_public_install_page(
-    connected_app_id: str = Field(
-        description="Identifier of the Release Management connected app for the installable artifact. This field is mandatory.",
-    ),
-    installable_artifact_id: str = Field(
-        description="The uuidv4 identifier for the installable artifact. This field is mandatory.",
-    ),
-    with_public_page: bool = Field(
-        description="Boolean flag for enabling/disabling public install page for the installable artifact. This field is mandatory.",
-    ),
-) -> str:
-    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/installable-artifacts/{installable_artifact_id}/public-install-page"
-    body = {
-        "with_public_page": with_public_page,
-    }
-    return await call_api("PATCH", url, body=body)
-
-
 # ===== Apps =====
 @mcp_tool(
     api_groups=["apps", "read-only"],
@@ -1328,6 +964,671 @@ async def add_member_to_group(
     api_groups=["user", "read-only"],
     description="Get user info for the currently authenticated user account",
 )
+
+# ===== Release Management =====
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Add a new Release Management connected app to Bitrise."
+)
+async def create_connected_app(
+    platform: str = Field(
+        description="The mobile platform for the connected app. Available values are 'ios' and 'android'.",
+    ),
+    store_app_id: str = Field(
+        description="The app store identifier for the connected app. In case of 'ios' platform it is the bundle id "
+                    "from App Store Connect. For additional context you can check the property description: "
+                    "https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier"
+                    "In case of Android platform it is the package name. Check the documentation: "
+                    "https://developer.android.com/build/configure-app-module#set_the_application_id",
+    ),
+    workspace_slug: str = Field(
+        description="Identifier of the Bitrise workspace for the Release Management connected app. This field is mandatory.",
+    ),
+    id: Optional[str] = Field(
+        default=None,
+        description="An uuidV4 identifier for your new connected app. If it is not given, one will be generated. It is "
+                    "useful for making the request idempotent or if the id is triggered outside of Bitrise and needs "
+                    "to be stored separately as well.",
+    ),
+    manual_connection: Optional[bool] = Field(
+        default=False,
+        description="If set to true it indicates a manual connection (bypassing using store api keys) and requires "
+                    "giving 'store_app_name' as well. This can be especially useful for enterprise apps.",
+    ),
+    project_id: Optional[str] = Field(
+        default=None,
+        description="Specifies which Bitrise Project you want to get the connected app to be associated with. If this field is not given a new project will be created alongside with the connected app.",
+    ),
+    store_app_name: Optional[str] = Field(
+        default=None,
+        description="If you have no active app store API keys added on Bitrise, you can decide to add your app manually by giving the app's name as well while indicating manual connection with the similarly named boolean flag.",
+    ),
+    store_credential_id: Optional[str] = Field(
+        default=None,
+        description="If you have credentials added on Bitrise, you can decide to select one for your app. In case of "
+                    "ios platform it will be an Apple API credential id. In case of android platform it will be a "
+                    "Google Service credential id.",
+    ),
+) -> str:
+    url = f"{BITRISE_RM_API_BASE}/connected-apps"
+    body = {
+        "platform": platform,
+        "store_app_id": store_app_id,
+        "workspace_slug": workspace_slug,
+        "id": id,
+        "manual_connection": manual_connection,
+        "project_id": project_id,
+        "store_app_name": store_app_name,
+        "store_credential_id": store_credential_id,
+    }
+    return await call_api("POST", url, body=body)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="List Release Management connected apps available for the authenticated account within a workspace.",
+)
+async def list_connected_apps(
+    workspace_slug: str = Field(
+        description="Identifier of the Bitrise workspace for the Release Management connected apps. This field is mandatory.",
+    ),
+    project_id: Optional[str] = Field(
+        default=None,
+        description="Specifies which Bitrise Project you want to get associated connected apps for",
+    ),
+    platform: Optional[str] = Field(
+        default=None,
+        description="Filters for a specific mobile platform for the list of connected apps. Available values are: 'ios' and 'android'.",
+    ),
+    search: Optional[str] = Field(
+        default=None,
+        description="Search by bundle ID (for ios), package name (for android), or app title (for both platforms). The filter is case-sensitive.",
+    ),
+    items_per_page: Optional[int] = Field(
+        default=10,
+        description="Specifies the maximum number of connected apps returned per page. Default value is 10.",
+    ),
+    page: Optional[int] = Field(
+        default=1,
+        description="Specifies which page should be returned from the whole result set in a paginated scenario. Default value is 1.",
+    ),
+) -> str:
+    params: Dict[str, Union[str, int]] = {}
+    if workspace_slug:
+        params["workspace_slug"] = workspace_slug
+    if project_id:
+        params["project_id"] = project_id
+    if platform:
+        params["platform"] = platform
+    if search:
+        params["search"] = search
+    if items_per_page:
+        params["items_per_page"] = items_per_page
+    if page:
+        params["page"] = page
+
+    url = f"{BITRISE_RM_API_BASE}/connected-apps"
+    return await call_api("GET", url, params=params)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Gives back a Release Management connected app for the authenticated account.",
+)
+async def get_connected_app(
+    id: str = Field(
+        description="Identifier of the Release Management connected app",
+    ),
+) -> str:
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/{id}"
+    return await call_api("GET", url)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Updates a connected app."
+)
+async def update_connected_app(
+    connected_app_id: str = Field(
+        description="The uuidV4 identifier for your connected app.",
+    ),
+    connect_to_store: Optional[bool] = Field(
+        default=False,
+        description="If true, will check connected app validity against the Apple App Store or Google Play Store "
+                    "(dependent on the platform of your connected app). This means, that the already set or just given "
+                    "store_app_id will be validated against the Store, using the already set or just given store "
+                    "credential id.",
+    ),
+    store_app_id: Optional[str] = Field(
+        description="The store identifier for your app. You can change the previously set store_app_id to match the "
+                "one in the App Store or Google Play depending on the app platform. This is especially useful if "
+                "you want to connect your app with the store as the system will validate the given store_app_id "
+                "against the Store. In case of iOS platform it is the bundle id. In case of Android platform it is "
+                "the package name.",
+    ),
+    store_credential_id: Optional[str] = Field(
+        default=None,
+        description="If you have credentials added on Bitrise, you can decide to select one for your app. In case of "
+                    "ios platform it will be an Apple API credential id. In case of android platform it will be a "
+                    "Google Service credential id.",
+    ),
+) -> str:
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}"
+    body = {
+        "connect_to_store": connect_to_store,
+        "store_app_id": store_app_id,
+        "store_credential_id": store_credential_id,
+    }
+    return await call_api("PATCH", url, body=body)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="List Release Management installable artifacts of a connected app available for the authenticated account.",
+)
+async def list_installable_artifacts(
+    connected_app_id: str = Field(
+        description="Identifier of the Release Management connected app for the installable artifacts. This field is mandatory.",
+    ),
+
+    after_date: Optional[str] = Field(
+        default=None,
+        description="A date in ISO 8601 string format specifying the start of the interval when the installable "
+                    "artifact to be returned was created or uploaded. This value will be defaulted to 1 month ago if "
+                    "distribution_ready filter is not set or set to false."
+    ),
+    artifact_type: Optional[str] = Field(
+        default=None,
+        description="Filters for a specific artifact type or file extension for the list of installable artifacts. "
+                    "Available values are: 'aab' and 'apk' for android artifacts and 'ipa' for ios artifacts."
+    ),
+    before_date: Optional[str] = Field(
+        default=None,
+        description="A date in ISO 8601 string format specifying the end of the interval when the installable artifact "
+                    "to be returned was created or uploaded. This value will be defaulted to the current time if "
+                    "distribution_ready filter is not set or set to false."
+    ),
+    branch: Optional[str] = Field(
+        default=None,
+        description="Filters for the Bitrise CI branch of the installable artifact on which it has been generated on.",
+    ),
+    distribution_ready: Optional[bool] = Field(
+        default=None,
+        description="Filters for distribution ready installable artifacts. This means .apk and .ipa (with "
+                    "distribution type ad-hoc, development, or enterprise) installable artifacts.",
+    ),
+    items_per_page: Optional[int] = Field(
+        default=10,
+        description="Specifies the maximum number of installable artifacts to be returned per page. Default value is 10.",
+    ),
+    page: Optional[int] = Field(
+        default=1,
+        description="Specifies which page should be returned from the whole result set in a paginated scenario. Default value is 1.",
+    ),
+    platform: Optional[str] = Field(
+        default=None,
+        description="Filters for a specific mobile platform for the list of installable artifacts. Available values are: 'ios' and 'android'.",
+    ),
+    search: Optional[str] = Field(
+        default=None,
+        description="Search by version, filename or build number (Bitrise CI). The filter is case-sensitive.",
+    ),
+    source: Optional[str] = Field(
+        default=None,
+        description="Filters for the source of installable artifacts to be returned. Available values are 'api' and "
+                    "'ci'."
+    ),
+    store_signed: Optional[bool] = Field(
+        default=None,
+        description="Filters for store ready installable artifacts. This means signed .aab and .ipa (with distribution type app-store) installable artifacts.",
+    ),
+    version: Optional[str] = Field(
+        default=None,
+        description="Filters for the version this installable artifact was created for. This field is required if the "
+                    "distribution_ready filter is set to true."
+    ),
+    workflow: Optional[str] = Field(
+        default=None,
+        description="Filters for the Bitrise CI workflow of the installable artifact it has been generated by.",
+    ),
+) -> str:
+    params: Dict[str, Union[str, int, bool]] = {}
+    if connected_app_id:
+        params["connected_app_id"] = connected_app_id
+
+    if after_date:
+        params["after_date"] = after_date
+    if artifact_type:
+        params["artifact_type"] = artifact_type
+    if before_date:
+        params["before_date"] = before_date
+    if branch:
+        params["branch"] = branch
+    if distribution_ready:
+        params["distribution_ready"] = distribution_ready
+    if items_per_page:
+        params["items_per_page"] = items_per_page
+    if page:
+        params["page"] = page
+    if platform:
+        params["platform"] = platform
+    if search:
+        params["search"] = search
+    if source:
+        params["source"] = source
+    if store_signed:
+        params["store_signed"] = store_signed
+    if version:
+        params["version"] = version
+    if workflow:
+        params["workflow"] = workflow
+
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/installable-artifacts"
+    return await call_api("GET", url, params=params)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Generates a signed upload url valid for 1 hour for an installable artifact to be uploaded to Bitrise "
+                "Release Management. The response will contain an url that can be used to upload an artifact to Bitrise "
+                "Release Management using a simple curl request with the file data that should be uploaded. The "
+                "necessary headers and http method will also be in the response. This artifact will need to be "
+                "processed after upload to be usable. The status of processing can be checked by making another request"
+                "to a different url giving back the processed status of an installable artifact.",
+)
+async def generate_installable_artifact_upload_url(
+    connected_app_id: str = Field(
+        description="Identifier of the Release Management connected app for the installable artifact. This field is mandatory.",
+    ),
+    installable_artifact_id: str = Field(
+        description="An uuidv4 identifier generated on the client side for the installable artifact. This field is "
+                    "mandatory.",
+    ),
+
+    file_name: str = Field(
+        description="The name of the installable artifact file (with extension) to be uploaded to Bitrise. This field "
+                    "is mandatory.",
+    ),
+    file_size_bytes: str = Field(
+        description="The byte size of the installable artifact file to be uploaded.",
+    ),
+
+    branch: Optional[str] = Field(
+        default=None,
+        description="Optionally you can add the name of the CI branch the installable artifact has been generated on.",
+    ),
+    with_public_page: Optional[bool] = Field(
+        default=None,
+        description="Optionally, you can enable public install page for your artifact. This can only be enabled by "
+                    "Bitrise Project Admins, Bitrise Project Owners and Bitrise Workspace Admins. Changing this value "
+                    "without proper permissions will result in an error. The default value is false.",
+    ),
+    workflow: Optional[str] = Field(
+        default=None,
+        description="Optionally you can add the name of the CI workflow this installable artifact has been generated by.",
+    ),
+) -> str:
+    params: Dict[str, Union[str, int, bool]] = {}
+    if connected_app_id:
+        params["connected_app_id"] = connected_app_id
+    if installable_artifact_id:
+        params["installable_artifact_id"] = installable_artifact_id
+
+    if file_name:
+        params["file_name"] = file_name
+    if file_size_bytes:
+        params["file_size_bytes"] = file_size_bytes
+
+    if branch:
+        params["branch"] = branch
+    if with_public_page:
+        params["with_public_page"] = with_public_page
+    if workflow:
+        params["workflow"] = workflow
+
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/installable-artifacts/{installable_artifact_id}/upload-url"
+    return await call_api("GET", url, params=params)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Gets the processing and upload status of an installable artifact. An artifact will need to be "
+                "processed after upload to be usable. This endpoint helps understanding when an uploaded installable "
+                "artifacts becomes usable for later purposes.",
+)
+async def get_installable_artifact_upload_and_processing_status(
+    connected_app_id: str = Field(
+        description="Identifier of the Release Management connected app for the installable artifact. This field is mandatory.",
+    ),
+    installable_artifact_id: str = Field(
+        description="The uuidv4 identifier for the installable artifact. This field is mandatory.",
+    ),
+) -> str:
+    params: Dict[str, Union[str, int, bool]] = {}
+    if connected_app_id:
+        params["connected_app_id"] = connected_app_id
+    if installable_artifact_id:
+        params["installable_artifact_id"] = installable_artifact_id
+
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/installable-artifacts/{installable_artifact_id}/status"
+    return await call_api("GET", url, params=params)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Changes whether public install page should be available for the installable artifact or not."
+)
+async def set_installable_artifact_public_install_page(
+    connected_app_id: str = Field(
+        description="Identifier of the Release Management connected app for the installable artifact. This field is mandatory.",
+    ),
+    installable_artifact_id: str = Field(
+        description="The uuidv4 identifier for the installable artifact. This field is mandatory.",
+    ),
+    with_public_page: bool = Field(
+        description="Boolean flag for enabling/disabling public install page for the installable artifact. This field is mandatory.",
+    ),
+) -> str:
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/installable-artifacts/{installable_artifact_id}/public-install-page"
+    body = {
+        "with_public_page": with_public_page,
+    }
+    return await call_api("PATCH", url, body=body)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Lists Build Distribution versions. Release Management offers a convenient, secure solution to "
+                "distribute the builds of your mobile apps to testers without having to engage with either TestFlight "
+                "or Google Play. Once you have installable artifacts, Bitrise can generate both private and public "
+                "install links that testers or other stakeholders can use to install the app on real devices via "
+                "over-the-air installation. Build distribution allows you to define tester groups that can receive "
+                "notifications about installable artifacts. The email takes the notified testers to the test build "
+                "page, from where they can install the app on their own device. Build distribution versions are the "
+                " app versions available for testers.",
+)
+async def list_build_distribution_versions(
+    connected_app_id: str = Field(
+        description="The uuidV4 identifier of the app the build distribution is connected to. This field is mandatory.",
+    ),
+    items_per_page: Optional[int] = Field(
+        default=10,
+        description="Specifies the maximum number of build distribution versions returned per page. Default value is 10.",
+    ),
+    page: Optional[int] = Field(
+        default=1,
+        description="Specifies which page should be returned from the whole result set in a paginated scenario. Default value is 1.",
+    ),
+) -> str:
+    params: Dict[str, Union[str, int]] = {}
+    if connected_app_id:
+        params["connected_app_id"] = connected_app_id
+    if items_per_page:
+        params["items_per_page"] = items_per_page
+    if page:
+        params["page"] = page
+
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/build-distributions"
+    return await call_api("GET", url, params=params)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Gives back a list of test builds for the given build distribution version.",
+)
+async def list_build_distribution_version_test_builds(
+    connected_app_id: str = Field(
+        description="The uuidV4 identifier of the app the build distribution is connected to. This field is mandatory.",
+    ),
+    version: str = Field(
+        description="The version of the build distribution. This field is mandatory.",
+    ),
+
+    items_per_page: Optional[int] = Field(
+        default=10,
+        description="Specifies the maximum number of test builds to return for a build distribution version per page. Default value is 10.",
+    ),
+    page: Optional[int] = Field(
+        default=1,
+        description="Specifies which page should be returned from the whole result set in a paginated scenario. Default value is 1.",
+    ),
+) -> str:
+    params: Dict[str, Union[str, int]] = {}
+    if connected_app_id:
+        params["connected_app_id"] = connected_app_id
+    if version:
+        params["version"] = version
+
+    if items_per_page:
+        params["items_per_page"] = items_per_page
+    if page:
+        params["page"] = page
+
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/build-distributions/test-builds"
+    return await call_api("GET", url, params=params)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Creates a tester group for a Release Management connected app. Tester groups can be used to distribute "
+                "installable artifacts to testers automatically. When a new installable artifact is available, the "
+                "tester groups can either automatically or manually be notified via email. The notification email will "
+                "contain a link to the installable artifact page for the artifact within Bitrise Release "
+                "Management. A Release Management connected app can have multiple tester groups. Project team members "
+                "of the connected app can be selected to be testers and added to the tester group. This endpoint has "
+                "an elevated access level requirement. Only the owner of the related Bitrise Workspace, a workspace "
+                "manager or the related project's admin can manage tester groups."
+)
+async def create_tester_group(
+    connected_app_id: str = Field(
+        description="The uuidV4 identifier of the related Release Management connected app.",
+    ),
+    name: str = Field(
+        description="The name for the new tester group. Must be unique in the scope of the connected app.",
+    ),
+    auto_notify: Optional[bool] = Field(
+        default=False,
+        description="If set to true it indicates that the tester group will receive notifications automatically.",
+    ),
+) -> str:
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/tester-groups"
+    body = {
+        "name": name,
+        "auto_notify": auto_notify,
+    }
+    return await call_api("POST", url, body=body)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Notifies a tester group about a new test build."
+)
+async def notify_tester_group(
+    connected_app_id: str = Field(
+        description="The uuidV4 identifier of the related Release Management connected app.",
+    ),
+    id: str = Field(
+        description="The uuidV4 identifier of the tester group whose members will be notified about the test build.",
+    ),
+    test_build_id: str = Field(
+        description="The unique identifier of the test build what will be sent in the notification of the tester group.",
+    ),
+) -> str:
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/tester-groups/{id}/notify"
+    body = {
+        "test_build_id": test_build_id,
+    }
+    return await call_api("POST", url, body=body)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Adds testers to a tester group of a connected app."
+)
+async def add_testers_to_tester_group(
+    connected_app_id: str = Field(
+        description="The uuidV4 identifier of the related Release Management connected app.",
+    ),
+    id: str = Field(
+        description="The uuidV4 identifier of the tester group to which testers will be added.",
+    ),
+    user_slugs: list[str] = Field(
+        description="The list of users identified by slugs that will be added to the tester group.",
+    ),
+) -> str:
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/tester-groups/{id}/add-testers"
+    body = {
+        "user_slugs": user_slugs,
+    }
+    return await call_api("POST", url, body=body)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Updates the given tester group. The name and the auto notification setting can be updated optionally."
+)
+async def update_tester_group(
+    connected_app_id: str = Field(
+        description="The uuidV4 identifier of the related Release Management connected app.",
+    ),
+    id: str = Field(
+        description="The uuidV4 identifier of the tester group to which testers will be added.",
+    ),
+    name: Optional[str] = Field(
+        default=None,
+        description="The new name for the tester group. Must be unique in the scope of the related connected app.",
+    ),
+    auto_notify: Optional[bool] = Field(
+        default=False,
+        description="If set to true it indicates the tester group will receive email notifications automatically from "
+                    "now on about new installable builds.",
+    ),
+) -> str:
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/tester-groups/{id}"
+    body = {
+        "name": name,
+        "auto_notify": auto_notify,
+    }
+    return await call_api("PUT", url, body=body)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Gives back a list of tester groups related to a specific Release Management connected app.",
+)
+async def list_tester_groups(
+    connected_app_id: str = Field(
+        description="The uuidV4 identifier of the app the tester group is connected to. This field is mandatory.",
+    ),
+
+    items_per_page: Optional[int] = Field(
+        default=10,
+        description="Specifies the maximum number of tester groups to return related to a specific connected app. Default value is 10.",
+    ),
+    page: Optional[int] = Field(
+        default=1,
+        description="Specifies which page should be returned from the whole result set in a paginated scenario. Default value is 1.",
+    ),
+) -> str:
+    params: Dict[str, Union[str, int]] = {}
+    if connected_app_id:
+        params["connected_app_id"] = connected_app_id
+
+    if items_per_page:
+        params["items_per_page"] = items_per_page
+    if page:
+        params["page"] = page
+
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/tester-groups"
+    return await call_api("GET", url, params=params)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Gives back the details of the selected tester group.",
+)
+async def get_tester_group(
+    connected_app_id: str = Field(
+        description="The uuidV4 identifier of the app the tester group is connected to. This field is mandatory.",
+    ),
+    id: str = Field(
+        description="The uuidV4 identifier of the tester group. This field is mandatory.",
+    ),
+) -> str:
+    params: Dict[str, Union[str, int]] = {}
+    if connected_app_id:
+        params["connected_app_id"] = connected_app_id
+    if id:
+        params["id"] = id
+
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/tester-groups/{id}"
+    return await call_api("GET", url, params=params)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Gets a list of potential testers whom can be added as testers to a specific tester group. The list "
+                "consists of Bitrise users having access to the related Release Management connected app.",
+)
+async def get_potential_testers(
+    connected_app_id: str = Field(
+        description="The uuidV4 identifier of the app the tester group is connected to. This field is mandatory.",
+    ),
+    id: str = Field(
+        description="The uuidV4 identifier of the tester group. This field is mandatory.",
+    ),
+    items_per_page: Optional[int] = Field(
+        default=10,
+        description="Specifies the maximum number of potential testers to return having access to a specific connected app. Default value is 10.",
+    ),
+    page: Optional[int] = Field(
+        default=1,
+        description="Specifies which page should be returned from the whole result set in a paginated scenario. Default value is 1.",
+    ),
+    search: Optional[str] = Field(
+        default=None,
+        description="Searches for potential testers based on email or username using a case-insensitive approach.",
+    ),
+) -> str:
+    params: Dict[str, Union[str, int]] = {}
+    if connected_app_id:
+        params["connected_app_id"] = connected_app_id
+    if id:
+        params["id"] = id
+
+    if items_per_page:
+        params["items_per_page"] = items_per_page
+    if page:
+        params["page"] = page
+    if search:
+        params["search"] = search
+
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/tester-groups/{id}/potential-testers"
+    return await call_api("GET", url, params=params)
+
+@mcp_tool(
+    api_groups=["release-management"],
+    description="Gives back a list of testers that has been associated with a tester group related to a specific "
+                "connected app.",
+)
+async def get_potential_testers(
+    connected_app_id: str = Field(
+        description="The uuidV4 identifier of the app the tester group is connected to. This field is mandatory.",
+    ),
+
+    tester_group_id: Optional[str] = Field(
+        description="The uuidV4 identifier of a tester group. If given, only testers within this specific tester group "
+                    "will be returned.",
+    ),
+    items_per_page: Optional[int] = Field(
+        default=10,
+        description="Specifies the maximum number of testers to be returned that have been added to a tester group "
+                    "related to the specific connected app.. Default value is 10.",
+    ),
+    page: Optional[int] = Field(
+        default=1,
+        description="Specifies which page should be returned from the whole result set in a paginated scenario. Default value is 1.",
+    ),
+) -> str:
+    params: Dict[str, Union[str, int]] = {}
+    if connected_app_id:
+        params["connected_app_id"] = connected_app_id
+
+    if tester_group_id:
+        params["tester_group_id"] = tester_group_id
+    if items_per_page:
+        params["items_per_page"] = items_per_page
+    if page:
+        params["page"] = page
+
+    url = f"{BITRISE_RM_API_BASE}/connected-apps/{connected_app_id}/testers"
+    return await call_api("GET", url, params=params)
+
+
 async def me() -> str:
     url = f"{BITRISE_API_BASE}/me"
     return await call_api("GET", url)


### PR DESCRIPTION
The PR contains a new api group called Release Management. The group has 17 endpoints from the [Release Management Public API](https://api.bitrise.io/release-management/api-docs) added as MCP tools. These endpoints are the ones for managing connected apps, installable artifacts and build distributions. These MCP tools are not containing the destructive endpoints of the Release Management Public API to prevent the AI driven workflows from making irrecoverable changes.

Release related endpoints will be added at a later time.