### PR TITLE
Add pipeline_id to trigger_bitrise_build in main.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Example configuration:
     - Arguments:
       - `app_slug`: Identifier of the Bitrise app
       - `branch` (optional): The branch to build (default: main)
+      - `pipeline_id` (optional): The pipeline to build
       - `workflow_id` (optional): The workflow to build
       - `commit_message` (optional): The commit message for the build
       - `commit_hash` (optional): The commit hash for the build

--- a/main.py
+++ b/main.py
@@ -390,6 +390,10 @@ async def trigger_bitrise_build(
         default=None,
         description="The workflow to build",
     ),
+    pipeline_id: str = Field(
+        default=None,
+        description="The pipeline to build",
+    ),
     commit_message: str = Field(
         default=None,
         description="The commit message for the build",
@@ -402,6 +406,8 @@ async def trigger_bitrise_build(
     url = f"{BITRISE_API_BASE}/apps/{app_slug}/builds"
     build_params = {"branch": branch}
 
+    if pipeline_id:
+        build_params["pipeline_id"] = pipeline_id
     if workflow_id:
         build_params["workflow_id"] = workflow_id
     if commit_message:


### PR DESCRIPTION
This PR introduces the `pipeline_id` to the tool metadata within the `trigger_bitrise_build`. 

This adds support triggering builds using a pipeline_id in addition to the existing workflow_id.