### PR TITLE
Fix default --enable-api-groups value and README to match actual API group ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Example configuration:
     - Arguments:
       - `app_slug`: Identifier of the Bitrise app
 
-### Build Artifacts
+### Artifacts
 
 19. `list_artifacts`
     - Get a list of all build artifacts
@@ -287,7 +287,7 @@ Example configuration:
       - `artifact_slug`: Identifier of the artifact
       - `is_public_page_enabled`: Enable public page for the artifact
 
-### Webhooks
+### Outgoing Webhooks
 
 23. `list_outgoing_webhooks`
     - List the outgoing webhooks of an app
@@ -576,7 +576,7 @@ Example configuration:
 
 The Bitrise MCP server organizes tools into API groups that can be enabled or disabled via command-line arguments. The table below shows which API groups each tool belongs to:
 
-| Tool | apps | builds | workspaces | webhooks | build-artifacts | group-roles | cache-items | pipelines | account | read-only | release-management |
+| Tool | apps | builds | workspaces | outgoing-webhooks | artifacts | group-roles | cache-items | pipelines | account | read-only | release-management |
 |------|------|--------|------------|----------|----------------|-------------|-------------|-----------|---------|-----------|-------------------|
 | list_apps | ✅ | | | | | | | | | ✅ | |
 | register_app | ✅ | | | | | | | | | | |

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ parser.add_argument(
     "--enabled-api-groups",
     help="The list of enabled API groups, comma separated",
     type=partial(str.split, sep=","),
-    default="apps,builds,workspaces,webhooks,build-artifacts,group-roles,cache-items,pipelines,account,read-only,release-management",
+    default="apps,builds,workspaces,outgoing-webhooks,artifacts,group-roles,cache-items,pipelines,account,read-only,release-management",
 )
 args = parser.parse_args()
 print(f"Enabled API groups {args.enabled_api_groups}", file=sys.stderr)


### PR DESCRIPTION
In v1.1.0 there is a mismatch between the actual group ids defined in the `@mcp_tool` decorator calls and those specified in the `README.md` and the default value for `--enable-api-groups`. Specifically `outgoing-webhooks` is referred to as `webhooks` and `artifacts` is referred to as `build-artifacts`.

The result is that members of `outgoing-webhooks` and `artifacts` API groups are excluded from the list of tools by default.

- delete_artifact
- update_artifact
- delete_outgoing_webhook
- update_outgoing_webhook
- create_outgoing_webhook

This PR updates the default value of `--enable-api-groups` and the references to API groups in the `README.md` to reflec the actual group ids. The result is that all tools are enabled by default.