### PR TITLE
Strip ANSI escape sequences from build logs

### DIFF
--- a/devenv/test-responses/build-logs/.gitignore
+++ b/devenv/test-responses/build-logs/.gitignore
@@ -1,0 +1,2 @@
+# Raw log fixtures may contain sensitive build output
+*.txt

--- a/devenv/test-responses/build-logs/collect.sh
+++ b/devenv/test-responses/build-logs/collect.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Collects raw build log fixtures (short, medium, large) for ANSI-stripping analysis.
+#
+# Pinned app: Bitrise iOS Simple (46b6b9a78a418ee8)
+# Fetches the 10 most recent builds, downloads their raw logs, then picks
+# the smallest, a medium-sized one, and the largest as the three fixtures.
+#
+# Usage:
+#   BITRISE_TOKEN=<token> bash devenv/test-responses/build-logs/collect.sh
+#
+# Requirements: curl, python3 (with tiktoken: pip install tiktoken)
+
+set -euo pipefail
+
+TOKEN="${BITRISE_TOKEN:?BITRISE_TOKEN must be set}"
+APP="46b6b9a78a418ee8"
+API="https://api.bitrise.io/v0.1"
+OUT="$(cd "$(dirname "$0")" && pwd)"
+
+echo "=== Listing recent builds ==="
+
+# status=1 (success) and status=2 (failed) both have archived logs
+builds_json=$(curl -sf -H "Authorization: $TOKEN" "$API/apps/$APP/builds?limit=20")
+build_slugs=$(echo "$builds_json" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for b in data.get('data', []):
+    if b.get('status', 0) != 0:  # 0 = still running
+        print(b['slug'])
+")
+
+echo "Found builds:"
+echo "$build_slugs"
+
+# Download log for each build, save to temp files with size info
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+declare -A log_sizes
+declare -A log_files
+
+for slug in $build_slugs; do
+    echo -n "  Fetching log for $slug ... "
+    log_meta=$(curl -sf -H "Authorization: $TOKEN" "$API/apps/$APP/builds/$slug/log" || true)
+    url=$(echo "$log_meta" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('expiring_raw_log_url', ''))
+" 2>/dev/null || true)
+
+    if [ -z "$url" ]; then
+        echo "no URL (build still running?), skipping"
+        continue
+    fi
+
+    tmpfile="$tmpdir/$slug.txt"
+    # Logs are plain text (not JSON) at the expiring URL
+    if curl -sf --max-time 30 "$url" -o "$tmpfile" 2>/dev/null; then
+        size=$(wc -c < "$tmpfile")
+        lines=$(wc -l < "$tmpfile")
+        echo "${size} bytes, ${lines} lines"
+        log_sizes[$slug]=$size
+        log_files[$slug]=$tmpfile
+    else
+        echo "download failed, skipping"
+    fi
+done
+
+if [ ${#log_files[@]} -eq 0 ]; then
+    echo "ERROR: no logs downloaded"
+    exit 1
+fi
+
+echo ""
+echo "=== Selecting short / medium / large fixtures ==="
+
+# Sort by size and pick three evenly-spaced fixtures
+python3 << PYEOF
+import os, shutil
+
+files = {
+$(for slug in "${!log_files[@]}"; do
+    echo "    '$slug': ('${log_files[$slug]}', ${log_sizes[$slug]}),"
+done)
+}
+
+sorted = sorted(files.items(), key=lambda x: x[1][1])
+n = len(sorted)
+out = "$OUT"
+
+picks = {}
+if n == 1:
+    picks = {"medium": sorted[0]}
+elif n == 2:
+    picks = {"short": sorted[0], "large": sorted[-1]}
+else:
+    mid_idx = n // 2
+    picks = {"short": sorted[0], "medium": sorted[mid_idx], "large": sorted[-1]}
+
+for label, (slug, (path, size)) in picks.items():
+    dest = os.path.join(out, f"{label}.txt")
+    shutil.copy(path, dest)
+    lines = open(path).read().count('\n')
+    print(f"  {label}: {slug}  ({size:,} bytes, {lines:,} lines)")
+PYEOF
+
+echo ""
+echo "Fixtures saved to $OUT/"
+ls -lh "$OUT"/*.txt

--- a/devenv/test-responses/build-logs/measure.sh
+++ b/devenv/test-responses/build-logs/measure.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Measures character and token savings from ANSI stripping across log fixtures.
+#
+# Usage:
+#   bash devenv/test-responses/build-logs/measure.sh
+#
+# Requirements: python3 with tiktoken (pip install tiktoken or: nix shell nixpkgs#python3Packages.tiktoken)
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+python3 << PYEOF
+import re, os, warnings
+warnings.filterwarnings("ignore")
+
+try:
+    import tiktoken
+    enc = tiktoken.get_encoding("cl100k_base")
+    have_tiktoken = True
+except ImportError:
+    have_tiktoken = False
+    print("WARNING: tiktoken not installed; skipping token counts. Run: pip install tiktoken\n")
+
+ansi = re.compile(r'\x1b(?:[@-Z\\\\-_]|\[[0-9;]*[a-zA-Z])')
+
+fixtures = ["short", "medium", "large", "known"]
+dir_ = "$DIR"
+
+rows = []
+for name in fixtures:
+    path = os.path.join(dir_, f"{name}.txt")
+    if not os.path.exists(path):
+        continue
+    text = open(path, "rb").read().decode("utf-8", errors="replace")
+    stripped = ansi.sub("", text)
+
+    chars_before = len(text)
+    chars_after  = len(stripped)
+    chars_saved  = chars_before - chars_after
+    chars_pct    = chars_saved / chars_before * 100 if chars_before else 0
+
+    seqs = len(ansi.findall(text))
+
+    if have_tiktoken:
+        tok_before = len(enc.encode(text))
+        tok_after  = len(enc.encode(stripped))
+        tok_saved  = tok_before - tok_after
+        tok_pct    = tok_saved / tok_before * 100 if tok_before else 0
+    else:
+        tok_before = tok_after = tok_saved = tok_pct = None
+
+    rows.append((name, chars_before, chars_after, chars_saved, chars_pct,
+                 seqs, tok_before, tok_after, tok_saved, tok_pct))
+
+# Print results
+print(f"{'Fixture':<10} {'Chars before':>14} {'Chars after':>12} {'Saved':>8} {'Saved%':>7}  {'ANSI seqs':>10}")
+print("-" * 67)
+for r in rows:
+    name, cb, ca, cs, cp, seqs, *_ = r
+    print(f"{name:<10} {cb:>14,} {ca:>12,} {cs:>8,} {cp:>6.1f}%  {seqs:>10,}")
+
+if have_tiktoken:
+    print()
+    print(f"{'Fixture':<10} {'Tokens before':>14} {'Tokens after':>13} {'Saved':>8} {'Saved%':>7}")
+    print("-" * 57)
+    for r in rows:
+        name, _, _, _, _, _, tb, ta, ts, tp = r
+        print(f"{name:<10} {tb:>14,} {ta:>13,} {ts:>8,} {tp:>6.1f}%")
+PYEOF

--- a/internal/tool/builds/get_build_log.go
+++ b/internal/tool/builds/get_build_log.go
@@ -6,12 +6,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
 	"github.com/mark3labs/mcp-go/mcp"
 )
+
+// ansiEscape matches ANSI/VT100 escape sequences (colors, cursor movement, etc.).
+// LLMs receive no benefit from these control codes; stripping them reduces token count.
+var ansiEscape = regexp.MustCompile(`\x1b(?:[@-Z\\-_]|\[[0-9;]*[a-zA-Z])`)
 
 type GetBuildLogResponse struct {
 	LogLines   string `json:"log_lines" jsonschema_description:"The requested lines of the build log."`
@@ -85,6 +90,7 @@ var GetBuildLog = bitrise.Tool{
 		if err != nil {
 			return mcp.NewToolResultErrorFromErr("get log", err), nil
 		}
+		log = ansiEscape.ReplaceAllString(log, "")
 		logWindow := logWindow{Log: log, Offset: offset, Limit: limit}
 		a, err := json.Marshal(logWindow.Peek())
 		if err != nil {


### PR DESCRIPTION
## Summary

Build logs returned by \`get_build_log\` contain ANSI escape sequences (colors, bold, reset codes) that are meaningless to an LLM but inflate token usage. This PR strips them before the log window is sliced and returned.

## Implementation

A single compiled regex applied after log content is fetched, before the \`logWindow\` slice:

\`\`\`go
var ansiEscape = regexp.MustCompile(\`\x1b(?:[@-Z\\-_]|\[[0-9;]*[a-zA-Z])\`)
// ...
log = ansiEscape.ReplaceAllString(log, "")
\`\`\`

## Experiment & findings

Collected three raw build log fixtures from the bitrise-website app (short: setup-multiarch-dev-image, medium: build-and-push-dev-amd64-image, large: build-and-upload-frontend-production) and measured the impact. Scripts in \`devenv/test-responses/build-logs/\` — fixtures are gitignored as potentially sensitive.

All sampled ANSI sequences were SGR-only (colors/bold/reset) — no cursor movement or screen-erase codes.

**Character savings:**

| Fixture | Lines | Before | After | Saved | Saved% |
|---|---:|---:|---:|---:|---:|
| short | 129 | 8,541 | 8,244 | 297 | 3.5% |
| medium | 509 | 31,521 | 30,938 | 583 | 1.8% |
| large | 5,814 | 635,839 | 634,156 | 1,683 | 0.3% |

**Token savings (cl100k_base):**

| Fixture | Lines | Before | After | Saved | Saved% |
|---|---:|---:|---:|---:|---:|
| short | 129 | 1,893 | 1,645 | 248 | 13.1% |
| medium | 509 | 11,450 | 10,982 | 468 | 4.1% |
| large | 5,814 | 219,016 | 217,687 | 1,329 | 0.6% |

**Key observations:**

- Token savings are disproportionately higher than character savings because ANSI sequences tokenize poorly (the tokenizer splits byte sequences like `\x1b[0m` into multiple tokens each).
- Shorter builds benefit most (~13%) — ANSI codes come from Bitrise step banners/status indicators, which are fixed overhead regardless of log length. In longer logs, the body is dominated by plain tool output (npm, webpack, etc.) with minimal ANSI codes, so the density drops.
- At the large end (219K tokens), stripping only saves ~1,300 tokens (0.6%) — the real problem there is the default limit of 2,000 lines, not ANSI codes.