### PR TITLE
Update docs with http type. 

### DIFF
--- a/docs/install-cursor.md
+++ b/docs/install-cursor.md
@@ -29,6 +29,7 @@ Uses Bitrise's hosted server at https://mcp.bitrise.io. Requires Cursor v0.48.0+
 {
   "mcpServers": {
     "bitrise": {
+      "type": "http",
       "url": "https://mcp.bitrise.io",
       "headers": {
         "Authorization": "Bearer YOUR_BITRISE_PAT"


### PR DESCRIPTION
Hey folks, I was trying to configure the bitrice MCP in my json file and without the _http_ type, was not working, so I am opening a PR to update the docs.