### PR TITLE
feat: add code signing file upload tools for Android and iOS

### DIFF
--- a/internal/bitrise/upload.go
+++ b/internal/bitrise/upload.go
@@ -1,0 +1,31 @@
+package bitrise
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// UploadFileToPresignedURL uploads file content to an AWS S3 presigned URL.
+// Unlike CallAPI, this does not add Bitrise auth headers — presigned URLs are self-authenticating.
+func UploadFileToPresignedURL(uploadURL string, content []byte) error {
+	req, err := http.NewRequest(http.MethodPut, uploadURL, bytes.NewReader(content))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.ContentLength = int64(len(content))
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	res, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute request: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode >= 400 {
+		resBody, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("unexpected status code %d; response body: %s", res.StatusCode, resBody)
+	}
+	return nil
+}

--- a/internal/tool/belt.go
+++ b/internal/tool/belt.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bitrise-io/bitrise-mcp/v2/internal/tool/artifacts"
 	"github.com/bitrise-io/bitrise-mcp/v2/internal/tool/builds"
 	"github.com/bitrise-io/bitrise-mcp/v2/internal/tool/cache"
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/tool/codesigning"
 	"github.com/bitrise-io/bitrise-mcp/v2/internal/tool/configuration"
 	"github.com/bitrise-io/bitrise-mcp/v2/internal/tool/grouproles"
 	"github.com/bitrise-io/bitrise-mcp/v2/internal/tool/pipelines"
@@ -41,6 +42,22 @@ func NewBelt() *Belt {
 		apps.ListBranches,
 		apps.RegisterSSHKey,
 		apps.RegisterWebhook,
+
+		// Code Signing
+		codesigning.UploadAndroidKeystoreFile,
+		codesigning.ListAndroidKeystoreFiles,
+		codesigning.GetAndroidKeystoreFile,
+		codesigning.DeleteAndroidKeystoreFile,
+		codesigning.UploadBuildCertificate,
+		codesigning.ListBuildCertificates,
+		codesigning.GetBuildCertificate,
+		codesigning.UpdateBuildCertificate,
+		codesigning.DeleteBuildCertificate,
+		codesigning.UploadProvisioningProfile,
+		codesigning.ListProvisioningProfiles,
+		codesigning.GetProvisioningProfile,
+		codesigning.UpdateProvisioningProfile,
+		codesigning.DeleteProvisioningProfile,
 
 		// Builds
 		builds.Trigger,

--- a/internal/tool/codesigning/android_keystore_delete.go
+++ b/internal/tool/codesigning/android_keystore_delete.go
@@ -1,0 +1,49 @@
+package codesigning
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+var DeleteAndroidKeystoreFile = bitrise.Tool{
+	APIGroups: []string{"apps"},
+	Definition: mcp.NewTool("delete_android_keystore_file",
+		mcp.WithDescription("Delete an Android keystore file from a Bitrise app."),
+		mcp.WithString("app_slug",
+			mcp.Description("Identifier of the Bitrise app"),
+			mcp.Required(),
+		),
+		mcp.WithString("keystore_slug",
+			mcp.Description("Identifier of the Android keystore file to delete"),
+			mcp.Required(),
+		),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(false),
+	),
+	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appSlug, err := request.RequireString("app_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		keystoreSlug, err := request.RequireString("keystore_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		res, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodDelete,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/android-keystore-files/%s", appSlug, keystoreSlug),
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("call api", err), nil
+		}
+		return mcp.NewToolResultText(res), nil
+	},
+}

--- a/internal/tool/codesigning/android_keystore_get.go
+++ b/internal/tool/codesigning/android_keystore_get.go
@@ -1,0 +1,49 @@
+package codesigning
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+var GetAndroidKeystoreFile = bitrise.Tool{
+	APIGroups: []string{"apps", "read-only"},
+	Definition: mcp.NewTool("get_android_keystore_file",
+		mcp.WithDescription("Get details of a specific Android keystore file for a Bitrise app."),
+		mcp.WithString("app_slug",
+			mcp.Description("Identifier of the Bitrise app"),
+			mcp.Required(),
+		),
+		mcp.WithString("keystore_slug",
+			mcp.Description("Identifier of the Android keystore file"),
+			mcp.Required(),
+		),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+	),
+	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appSlug, err := request.RequireString("app_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		keystoreSlug, err := request.RequireString("keystore_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		res, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodGet,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/android-keystore-files/%s", appSlug, keystoreSlug),
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("call api", err), nil
+		}
+		return mcp.NewToolResultText(res), nil
+	},
+}

--- a/internal/tool/codesigning/android_keystore_list.go
+++ b/internal/tool/codesigning/android_keystore_list.go
@@ -1,0 +1,56 @@
+package codesigning
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+var ListAndroidKeystoreFiles = bitrise.Tool{
+	APIGroups: []string{"apps", "read-only"},
+	Definition: mcp.NewTool("list_android_keystore_files",
+		mcp.WithDescription("List all Android keystore files for a Bitrise app."),
+		mcp.WithString("app_slug",
+			mcp.Description("Identifier of the Bitrise app"),
+			mcp.Required(),
+		),
+		mcp.WithString("next",
+			mcp.Description("Slug of the first keystore file to return (for pagination)"),
+		),
+		mcp.WithString("limit",
+			mcp.Description("Maximum number of results to return (default: 50)"),
+		),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+	),
+	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appSlug, err := request.RequireString("app_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		params := map[string]any{}
+		if v := request.GetString("next", ""); v != "" {
+			params["next"] = v
+		}
+		if v := request.GetString("limit", ""); v != "" {
+			params["limit"] = v
+		}
+
+		res, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodGet,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/android-keystore-files", appSlug),
+			Params:  params,
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("call api", err), nil
+		}
+		return mcp.NewToolResultText(res), nil
+	},
+}

--- a/internal/tool/codesigning/android_keystore_upload.go
+++ b/internal/tool/codesigning/android_keystore_upload.go
@@ -1,0 +1,118 @@
+package codesigning
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+var UploadAndroidKeystoreFile = bitrise.Tool{
+	APIGroups: []string{"apps"},
+	Definition: mcp.NewTool("upload_android_keystore_file",
+		mcp.WithDescription("Upload an Android keystore file to a Bitrise app for code signing. Reads the file from a local path, uploads it to Bitrise, and confirms the upload in a single operation."),
+		mcp.WithString("app_slug",
+			mcp.Description("Identifier of the Bitrise app"),
+			mcp.Required(),
+		),
+		mcp.WithString("file_path",
+			mcp.Description("Local filesystem path to the keystore file (e.g. /Users/me/release.jks)"),
+			mcp.Required(),
+		),
+		mcp.WithString("alias",
+			mcp.Description("Keystore alias"),
+			mcp.Required(),
+		),
+		mcp.WithString("keystore_password",
+			mcp.Description("Password for the keystore"),
+			mcp.Required(),
+		),
+		mcp.WithString("private_key_password",
+			mcp.Description("Password for the private key within the keystore"),
+			mcp.Required(),
+		),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(false),
+	),
+	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appSlug, err := request.RequireString("app_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		filePath, err := request.RequireString("file_path")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		alias, err := request.RequireString("alias")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		keystorePassword, err := request.RequireString("keystore_password")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		privateKeyPassword, err := request.RequireString("private_key_password")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("read file: %s", err)), nil
+		}
+		fileName := filepath.Base(filePath)
+
+		createRes, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodPost,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/android-keystore-files", appSlug),
+			Body: map[string]any{
+				"upload_file_name":     fileName,
+				"upload_file_size":     len(content),
+				"alias":                alias,
+				"password":             keystorePassword,
+				"private_key_password": privateKeyPassword,
+			},
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("create upload entry", err), nil
+		}
+
+		var parsed struct {
+			Data struct {
+				UploadURL string `json:"upload_url"`
+				Slug      string `json:"slug"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal([]byte(createRes), &parsed); err != nil {
+			return mcp.NewToolResultErrorFromErr("parse create response", err), nil
+		}
+		if parsed.Data.UploadURL == "" {
+			return mcp.NewToolResultError("API did not return an upload URL"), nil
+		}
+		if parsed.Data.Slug == "" {
+			return mcp.NewToolResultError("API did not return a file slug"), nil
+		}
+
+		if err := bitrise.UploadFileToPresignedURL(parsed.Data.UploadURL, content); err != nil {
+			return mcp.NewToolResultErrorFromErr("upload file", err), nil
+		}
+
+		confirmRes, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodPost,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/android-keystore-files/%s/uploaded", appSlug, parsed.Data.Slug),
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("confirm upload", err), nil
+		}
+		return mcp.NewToolResultText(confirmRes), nil
+	},
+}

--- a/internal/tool/codesigning/build_certificate_delete.go
+++ b/internal/tool/codesigning/build_certificate_delete.go
@@ -1,0 +1,49 @@
+package codesigning
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+var DeleteBuildCertificate = bitrise.Tool{
+	APIGroups: []string{"apps"},
+	Definition: mcp.NewTool("delete_build_certificate",
+		mcp.WithDescription("Delete an iOS build certificate from a Bitrise app."),
+		mcp.WithString("app_slug",
+			mcp.Description("Identifier of the Bitrise app"),
+			mcp.Required(),
+		),
+		mcp.WithString("certificate_slug",
+			mcp.Description("Identifier of the build certificate to delete"),
+			mcp.Required(),
+		),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(false),
+	),
+	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appSlug, err := request.RequireString("app_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		certificateSlug, err := request.RequireString("certificate_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		res, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodDelete,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/build-certificates/%s", appSlug, certificateSlug),
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("call api", err), nil
+		}
+		return mcp.NewToolResultText(res), nil
+	},
+}

--- a/internal/tool/codesigning/build_certificate_get.go
+++ b/internal/tool/codesigning/build_certificate_get.go
@@ -1,0 +1,49 @@
+package codesigning
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+var GetBuildCertificate = bitrise.Tool{
+	APIGroups: []string{"apps", "read-only"},
+	Definition: mcp.NewTool("get_build_certificate",
+		mcp.WithDescription("Get details of a specific iOS build certificate for a Bitrise app."),
+		mcp.WithString("app_slug",
+			mcp.Description("Identifier of the Bitrise app"),
+			mcp.Required(),
+		),
+		mcp.WithString("certificate_slug",
+			mcp.Description("Identifier of the build certificate"),
+			mcp.Required(),
+		),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+	),
+	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appSlug, err := request.RequireString("app_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		certificateSlug, err := request.RequireString("certificate_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		res, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodGet,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/build-certificates/%s", appSlug, certificateSlug),
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("call api", err), nil
+		}
+		return mcp.NewToolResultText(res), nil
+	},
+}

--- a/internal/tool/codesigning/build_certificate_list.go
+++ b/internal/tool/codesigning/build_certificate_list.go
@@ -1,0 +1,56 @@
+package codesigning
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+var ListBuildCertificates = bitrise.Tool{
+	APIGroups: []string{"apps", "read-only"},
+	Definition: mcp.NewTool("list_build_certificates",
+		mcp.WithDescription("List all iOS build certificates (.p12 files) for a Bitrise app."),
+		mcp.WithString("app_slug",
+			mcp.Description("Identifier of the Bitrise app"),
+			mcp.Required(),
+		),
+		mcp.WithString("next",
+			mcp.Description("Slug of the first certificate to return (for pagination)"),
+		),
+		mcp.WithString("limit",
+			mcp.Description("Maximum number of results to return (default: 50)"),
+		),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+	),
+	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appSlug, err := request.RequireString("app_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		params := map[string]any{}
+		if v := request.GetString("next", ""); v != "" {
+			params["next"] = v
+		}
+		if v := request.GetString("limit", ""); v != "" {
+			params["limit"] = v
+		}
+
+		res, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodGet,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/build-certificates", appSlug),
+			Params:  params,
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("call api", err), nil
+		}
+		return mcp.NewToolResultText(res), nil
+	},
+}

--- a/internal/tool/codesigning/build_certificate_update.go
+++ b/internal/tool/codesigning/build_certificate_update.go
@@ -1,0 +1,71 @@
+package codesigning
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+var UpdateBuildCertificate = bitrise.Tool{
+	APIGroups: []string{"apps"},
+	Definition: mcp.NewTool("update_build_certificate",
+		mcp.WithDescription("Update metadata for an iOS build certificate. Note: once is_protected is set to true it cannot be changed back."),
+		mcp.WithString("app_slug",
+			mcp.Description("Identifier of the Bitrise app"),
+			mcp.Required(),
+		),
+		mcp.WithString("certificate_slug",
+			mcp.Description("Identifier of the build certificate"),
+			mcp.Required(),
+		),
+		mcp.WithString("certificate_password",
+			mcp.Description("Password for the .p12 certificate file"),
+		),
+		mcp.WithBoolean("is_protected",
+			mcp.Description("Mark the certificate as protected (irreversible once set to true)"),
+		),
+		mcp.WithBoolean("is_expose",
+			mcp.Description("Whether to expose the certificate to pull request builds"),
+		),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+	),
+	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appSlug, err := request.RequireString("app_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		certificateSlug, err := request.RequireString("certificate_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		body := map[string]any{}
+		args := request.GetArguments()
+		if _, ok := args["certificate_password"]; ok {
+			body["certificate_password"] = request.GetString("certificate_password", "")
+		}
+		if _, ok := args["is_protected"]; ok {
+			body["is_protected"] = request.GetBool("is_protected", false)
+		}
+		if _, ok := args["is_expose"]; ok {
+			body["is_expose"] = request.GetBool("is_expose", false)
+		}
+
+		res, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodPatch,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/build-certificates/%s", appSlug, certificateSlug),
+			Body:    body,
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("call api", err), nil
+		}
+		return mcp.NewToolResultText(res), nil
+	},
+}

--- a/internal/tool/codesigning/build_certificate_upload.go
+++ b/internal/tool/codesigning/build_certificate_upload.go
@@ -1,0 +1,108 @@
+package codesigning
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+var UploadBuildCertificate = bitrise.Tool{
+	APIGroups: []string{"apps"},
+	Definition: mcp.NewTool("upload_build_certificate",
+		mcp.WithDescription("Upload an iOS build certificate (.p12 file) to a Bitrise app for code signing. Reads the file from a local path, uploads it to Bitrise, and sets the certificate password in a single operation."),
+		mcp.WithString("app_slug",
+			mcp.Description("Identifier of the Bitrise app"),
+			mcp.Required(),
+		),
+		mcp.WithString("file_path",
+			mcp.Description("Local filesystem path to the .p12 certificate file (e.g. /Users/me/Certificates.p12)"),
+			mcp.Required(),
+		),
+		mcp.WithString("certificate_password",
+			mcp.Description("Password for the .p12 certificate file (leave empty if the certificate has no password)"),
+		),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(false),
+	),
+	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appSlug, err := request.RequireString("app_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		filePath, err := request.RequireString("file_path")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("read file: %s", err)), nil
+		}
+		fileName := filepath.Base(filePath)
+
+		createRes, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodPost,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/build-certificates", appSlug),
+			Body: map[string]any{
+				"upload_file_name": fileName,
+				"upload_file_size": len(content),
+			},
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("create upload entry", err), nil
+		}
+
+		var parsed struct {
+			Data struct {
+				UploadURL string `json:"upload_url"`
+				Slug      string `json:"slug"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal([]byte(createRes), &parsed); err != nil {
+			return mcp.NewToolResultErrorFromErr("parse create response", err), nil
+		}
+		if parsed.Data.UploadURL == "" {
+			return mcp.NewToolResultError("API did not return an upload URL"), nil
+		}
+		if parsed.Data.Slug == "" {
+			return mcp.NewToolResultError("API did not return a file slug"), nil
+		}
+
+		if err := bitrise.UploadFileToPresignedURL(parsed.Data.UploadURL, content); err != nil {
+			return mcp.NewToolResultErrorFromErr("upload file", err), nil
+		}
+
+		confirmRes, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodPost,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/build-certificates/%s/uploaded", appSlug, parsed.Data.Slug),
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("confirm upload", err), nil
+		}
+
+		if password := request.GetString("certificate_password", ""); password != "" {
+			patchRes, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+				Method:  http.MethodPatch,
+				BaseURL: bitrise.APIBaseURL,
+				Path:    fmt.Sprintf("/apps/%s/build-certificates/%s", appSlug, parsed.Data.Slug),
+				Body:    map[string]any{"certificate_password": password},
+			})
+			if err != nil {
+				return mcp.NewToolResultErrorFromErr("set certificate password", err), nil
+			}
+			return mcp.NewToolResultText(patchRes), nil
+		}
+
+		return mcp.NewToolResultText(confirmRes), nil
+	},
+}

--- a/internal/tool/codesigning/provisioning_profile_delete.go
+++ b/internal/tool/codesigning/provisioning_profile_delete.go
@@ -1,0 +1,49 @@
+package codesigning
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+var DeleteProvisioningProfile = bitrise.Tool{
+	APIGroups: []string{"apps"},
+	Definition: mcp.NewTool("delete_provisioning_profile",
+		mcp.WithDescription("Delete an iOS provisioning profile from a Bitrise app."),
+		mcp.WithString("app_slug",
+			mcp.Description("Identifier of the Bitrise app"),
+			mcp.Required(),
+		),
+		mcp.WithString("profile_slug",
+			mcp.Description("Identifier of the provisioning profile to delete"),
+			mcp.Required(),
+		),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(false),
+	),
+	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appSlug, err := request.RequireString("app_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		profileSlug, err := request.RequireString("profile_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		res, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodDelete,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/provisioning-profiles/%s", appSlug, profileSlug),
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("call api", err), nil
+		}
+		return mcp.NewToolResultText(res), nil
+	},
+}

--- a/internal/tool/codesigning/provisioning_profile_get.go
+++ b/internal/tool/codesigning/provisioning_profile_get.go
@@ -1,0 +1,49 @@
+package codesigning
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+var GetProvisioningProfile = bitrise.Tool{
+	APIGroups: []string{"apps", "read-only"},
+	Definition: mcp.NewTool("get_provisioning_profile",
+		mcp.WithDescription("Get details of a specific iOS provisioning profile for a Bitrise app."),
+		mcp.WithString("app_slug",
+			mcp.Description("Identifier of the Bitrise app"),
+			mcp.Required(),
+		),
+		mcp.WithString("profile_slug",
+			mcp.Description("Identifier of the provisioning profile"),
+			mcp.Required(),
+		),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+	),
+	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appSlug, err := request.RequireString("app_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		profileSlug, err := request.RequireString("profile_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		res, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodGet,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/provisioning-profiles/%s", appSlug, profileSlug),
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("call api", err), nil
+		}
+		return mcp.NewToolResultText(res), nil
+	},
+}

--- a/internal/tool/codesigning/provisioning_profile_list.go
+++ b/internal/tool/codesigning/provisioning_profile_list.go
@@ -1,0 +1,56 @@
+package codesigning
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+var ListProvisioningProfiles = bitrise.Tool{
+	APIGroups: []string{"apps", "read-only"},
+	Definition: mcp.NewTool("list_provisioning_profiles",
+		mcp.WithDescription("List all iOS provisioning profiles for a Bitrise app."),
+		mcp.WithString("app_slug",
+			mcp.Description("Identifier of the Bitrise app"),
+			mcp.Required(),
+		),
+		mcp.WithString("next",
+			mcp.Description("Slug of the first provisioning profile to return (for pagination)"),
+		),
+		mcp.WithString("limit",
+			mcp.Description("Maximum number of results to return (default: 50)"),
+		),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+	),
+	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appSlug, err := request.RequireString("app_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		params := map[string]any{}
+		if v := request.GetString("next", ""); v != "" {
+			params["next"] = v
+		}
+		if v := request.GetString("limit", ""); v != "" {
+			params["limit"] = v
+		}
+
+		res, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodGet,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/provisioning-profiles", appSlug),
+			Params:  params,
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("call api", err), nil
+		}
+		return mcp.NewToolResultText(res), nil
+	},
+}

--- a/internal/tool/codesigning/provisioning_profile_update.go
+++ b/internal/tool/codesigning/provisioning_profile_update.go
@@ -1,0 +1,65 @@
+package codesigning
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+var UpdateProvisioningProfile = bitrise.Tool{
+	APIGroups: []string{"apps"},
+	Definition: mcp.NewTool("update_provisioning_profile",
+		mcp.WithDescription("Update metadata for an iOS provisioning profile. Note: once is_protected is set to true it cannot be changed back."),
+		mcp.WithString("app_slug",
+			mcp.Description("Identifier of the Bitrise app"),
+			mcp.Required(),
+		),
+		mcp.WithString("profile_slug",
+			mcp.Description("Identifier of the provisioning profile"),
+			mcp.Required(),
+		),
+		mcp.WithBoolean("is_protected",
+			mcp.Description("Mark the profile as protected (irreversible once set to true)"),
+		),
+		mcp.WithBoolean("is_expose",
+			mcp.Description("Whether to expose the profile to pull request builds"),
+		),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+	),
+	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appSlug, err := request.RequireString("app_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		profileSlug, err := request.RequireString("profile_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		body := map[string]any{}
+		args := request.GetArguments()
+		if _, ok := args["is_protected"]; ok {
+			body["is_protected"] = request.GetBool("is_protected", false)
+		}
+		if _, ok := args["is_expose"]; ok {
+			body["is_expose"] = request.GetBool("is_expose", false)
+		}
+
+		res, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodPatch,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/provisioning-profiles/%s", appSlug, profileSlug),
+			Body:    body,
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("call api", err), nil
+		}
+		return mcp.NewToolResultText(res), nil
+	},
+}

--- a/internal/tool/codesigning/provisioning_profile_upload.go
+++ b/internal/tool/codesigning/provisioning_profile_upload.go
@@ -1,0 +1,91 @@
+package codesigning
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+var UploadProvisioningProfile = bitrise.Tool{
+	APIGroups: []string{"apps"},
+	Definition: mcp.NewTool("upload_provisioning_profile",
+		mcp.WithDescription("Upload an iOS provisioning profile (.mobileprovision file) to a Bitrise app for code signing. Reads the file from a local path and uploads it to Bitrise in a single operation."),
+		mcp.WithString("app_slug",
+			mcp.Description("Identifier of the Bitrise app"),
+			mcp.Required(),
+		),
+		mcp.WithString("file_path",
+			mcp.Description("Local filesystem path to the provisioning profile file (e.g. /Users/me/MyApp.mobileprovision)"),
+			mcp.Required(),
+		),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(false),
+	),
+	Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appSlug, err := request.RequireString("app_slug")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		filePath, err := request.RequireString("file_path")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("read file: %s", err)), nil
+		}
+		fileName := filepath.Base(filePath)
+
+		createRes, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodPost,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/provisioning-profiles", appSlug),
+			Body: map[string]any{
+				"upload_file_name": fileName,
+				"upload_file_size": len(content),
+			},
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("create upload entry", err), nil
+		}
+
+		var parsed struct {
+			Data struct {
+				UploadURL string `json:"upload_url"`
+				Slug      string `json:"slug"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal([]byte(createRes), &parsed); err != nil {
+			return mcp.NewToolResultErrorFromErr("parse create response", err), nil
+		}
+		if parsed.Data.UploadURL == "" {
+			return mcp.NewToolResultError("API did not return an upload URL"), nil
+		}
+		if parsed.Data.Slug == "" {
+			return mcp.NewToolResultError("API did not return a file slug"), nil
+		}
+
+		if err := bitrise.UploadFileToPresignedURL(parsed.Data.UploadURL, content); err != nil {
+			return mcp.NewToolResultErrorFromErr("upload file", err), nil
+		}
+
+		confirmRes, err := bitrise.CallAPI(ctx, bitrise.CallAPIParams{
+			Method:  http.MethodPost,
+			BaseURL: bitrise.APIBaseURL,
+			Path:    fmt.Sprintf("/apps/%s/provisioning-profiles/%s/uploaded", appSlug, parsed.Data.Slug),
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("confirm upload", err), nil
+		}
+		return mcp.NewToolResultText(confirmRes), nil
+	},
+}


### PR DESCRIPTION
## Summary

Adds MCP tools for uploading and managing Android keystore files, iOS
build certificates (.p12), and iOS provisioning profiles. This enables
Claude to handle the full code signing setup for a mobile app from a
single user prompt — without requiring the user to touch the Bitrise UI
or run any shell commands.

## What's new

**3 upload tools** (one per file type) that own the complete Bitrise
upload flow internally:
1. POST to Bitrise API to create the file entry and get a presigned S3 URL
2. PUT the file bytes directly to S3
3. POST to confirm the upload

Claude reads the file from a local path provided by the user, so the
only interaction needed is the user typing a file path (and any
credentials like keystore alias/password).

**11 management tools** for day-to-day operations: list, get, delete
for all three file types, plus update (is_protected, is_expose) for
certificates and profiles, and certificate_password patching for .p12s.

**New `bitrise.UploadFileToPresignedURL` helper** — a plain HTTP PUT to
S3 without Bitrise auth headers, which presigned URLs require.

## Files changed

- `internal/bitrise/upload.go` — new S3 upload helper
- `internal/tool/codesigning/` — 14 new tool files
- `internal/tool/belt.go` — registers all new tools

## Testing

All 17 API endpoints verified with a live integration test against the
Bitrise API, including upload → get → delete round-trips and credential
field verification for Android keystores.