### PR TITLE
fix: return structured content from get_build_log

### DIFF
--- a/internal/tool/builds/get_build_log.go
+++ b/internal/tool/builds/get_build_log.go
@@ -86,11 +86,7 @@ var GetBuildLog = bitrise.Tool{
 			return mcp.NewToolResultErrorFromErr("get log", err), nil
 		}
 		logWindow := logWindow{Log: log, Offset: offset, Limit: limit}
-		a, err := json.Marshal(logWindow.Peek())
-		if err != nil {
-			return mcp.NewToolResultErrorFromErr("marshal log window", err), nil
-		}
-		return mcp.NewToolResultText(string(a)), nil
+		return mcp.NewToolResultStructuredOnly(logWindow.Peek()), nil
 	},
 }
 
@@ -135,6 +131,9 @@ func getStepLog(resBitriseRaw string) (string, error) {
 	}
 	if err := json.Unmarshal([]byte(resBitriseRaw), &resBitrise); err != nil {
 		return "", fmt.Errorf("unmarshal bitrise response: %w", err)
+	}
+	if resBitrise.URL == "" {
+		return "[incomplete log: processing is still ongoing]", nil
 	}
 
 	rawLog, err := httpGet(resBitrise.URL)


### PR DESCRIPTION
## Summary

- `get_build_log` declared `WithOutputSchema[GetBuildLogResponse]()` but returned `mcp.NewToolResultText()` on the success path, causing MCP error `-32600` ("Tool has an output schema but did not return structured content") on every call. Switch to `mcp.NewToolResultStructuredOnly()` — the same pattern all other output-schema tools in this repo already use.
- Guard against an empty `expiring_raw_log_url` in `getStepLog`: when a build is still in progress the API returns an empty URL, which previously caused an opaque `httpGet` network failure. Now returns `"[incomplete log: processing is still ongoing]"`, consistent with how `getFullLog` already handles this case.

## Test plan

- [x] `go test ./internal/tool/builds/...` passes
- [x] Verified locally against a real build (`d357177d-7383-46bf-a54f-24f587a3134b` / `5dd9c633-97f9-4ff1-be4d-86c78179b3f3`) via `claude mcp add` pointing at the local binary — tool now returns structured JSON instead of the -32600 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)