### PR TITLE
docs: make OAuth the default auth path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ MCP Server for the Bitrise API, enabling app management, build operations, artif
 ## Features
 
 - **Comprehensive API Access**: Access to Bitrise APIs including apps, builds, artifacts, and more.
-- **Authentication Support**: Secure API token-based access to Bitrise resources.
+- **OAuth-based Authentication**: Sign in once with your Bitrise account — no need to copy a Personal Access Token. (PAT-based auth still supported for clients that don't speak MCP OAuth.)
 - **Detailed Documentation**: [Well-documented tools with parameter descriptions](/docs/tools.md).
 
 ## Installation

--- a/docs/install-claude.md
+++ b/docs/install-claude.md
@@ -3,13 +3,31 @@
 ## Claude Code CLI
 
 ### Prerequisites
-- Claude Code CLI installed
-- [Create a Bitrise API Token](https://devcenter.bitrise.io/api/authentication):
-   - Go to your [Bitrise Account Settings/Security](https://app.bitrise.io/me/account/security).
-   - Navigate to the "Personal access tokens" section.
-   - Copy the generated token.
-- For local setup: [Go](https://go.dev/) (>=1.25) installed
+- Claude Code CLI installed (recent version, with MCP OAuth support)
+- A Bitrise account
 - Open Claude Code inside the directory for your project (recommended for best experience and clear scope of configuration)
+
+### Remote Server Setup (Streamable HTTP) — Recommended
+
+The remote server uses OAuth to authenticate you against your Bitrise account. No token to copy or paste.
+
+1. Add the server:
+   ```bash
+   claude mcp add --transport http bitrise https://mcp.bitrise.io
+   ```
+2. Restart Claude Code.
+3. On the first tool use, Claude Code will open your browser to sign in. Log in to Bitrise (or confirm your existing session) and approve the consent screen.
+4. Run `claude mcp list` to confirm the server is configured.
+
+#### Fallback: PAT-based authentication
+
+If you're on a Claude Code version without MCP OAuth support, or you'd prefer to use a Personal Access Token:
+
+1. [Create a Bitrise API Token](https://devcenter.bitrise.io/api/authentication) under [Account Settings → Security](https://app.bitrise.io/me/account/security).
+2. Add the server with the token as a Bearer header:
+   ```bash
+   claude mcp add --transport http bitrise https://mcp.bitrise.io -H "Authorization: Bearer YOUR_BITRISE_PAT"
+   ```
 
 <details>
 <summary><b>Storing Your PAT Securely</b></summary>
@@ -27,35 +45,30 @@ BITRISE_PAT=your_token_here
 echo -e ".env\n.mcp.json" >> .gitignore
 ```
 
-</details>
-
-### Remote Server Setup (Streamable HTTP)
-
-1. Run the following command in the Claude Code CLI
-```bash
-claude mcp add --transport http bitrise https://mcp.bitrise.io -H "Authorization: Bearer YOUR_BITRISE_PAT"
-```
-
-With an environment variable:
+3. Reference it when adding:
 ```bash
 claude mcp add --transport http bitrise https://mcp.bitrise.io -H "Authorization: Bearer $(grep BITRISE_PAT .env | cut -d '=' -f2)"
 ```
-2. Restart Claude Code
-3. Run `claude mcp list` to see if the Bitrise server is configured
+
+</details>
 
 ### Local Server Setup (Go required)
 
-1. Run the following command in the Claude Code CLI:
-```bash
-claude mcp add bitrise -e BITRISE_TOKEN=YOUR_BITRISE_PAT -- go run github.com/bitrise-io/bitrise-mcp/v2@v2
-```
+The local server runs in stdio mode and authenticates with a Personal Access Token (no browser OAuth flow in stdio mode).
 
-With an environment variable:
-```bash
-claude mcp add bitrise -e BITRISE_TOKEN=$(grep BITRISE_PAT .env | cut -d '=' -f2) -- go run github.com/bitrise-io/bitrise-mcp/v2@v2
-```
-2. Restart Claude Code
-3. Run `claude mcp list` to see if the Bitrise server is configured
+Prerequisites: [Go](https://go.dev/) (>=1.25) installed and a Bitrise PAT.
+
+1. Run:
+   ```bash
+   claude mcp add bitrise -e BITRISE_TOKEN=YOUR_BITRISE_PAT -- go run github.com/bitrise-io/bitrise-mcp/v2@v2
+   ```
+
+   With an environment variable:
+   ```bash
+   claude mcp add bitrise -e BITRISE_TOKEN=$(grep BITRISE_PAT .env | cut -d '=' -f2) -- go run github.com/bitrise-io/bitrise-mcp/v2@v2
+   ```
+2. Restart Claude Code.
+3. Run `claude mcp list` to see if the Bitrise server is configured.
 
 ### Verification
 ```bash
@@ -67,23 +80,34 @@ claude mcp get bitrise
 
 ### Prerequisites
 - Claude Desktop installed (latest version)
-- [Create a Bitrise API Token](https://devcenter.bitrise.io/api/authentication):
-   - Go to your [Bitrise Account Settings/Security](https://app.bitrise.io/me/account/security).
-   - Navigate to the "Personal access tokens" section.
-   - Copy the generated token.
-- For local setup: [Go](https://go.dev/) (>=1.25) installed
+- A Bitrise account
 
 ### Configuration File Location
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 - **Linux**: `~/.config/Claude/claude_desktop_config.json`
 
-### Remote Server setup (Streamable HTTP)
+### Remote Server setup (Streamable HTTP) — Recommended
 
-See [Claude | Connecting to a Remote MCP Server
-](https://modelcontextprotocol.io/docs/develop/connect-remote-servers#connecting-to-a-remote-mcp-server) for more details.
+Recent Claude Desktop versions support MCP OAuth natively. See [Claude | Connecting to a Remote MCP Server](https://modelcontextprotocol.io/docs/develop/connect-remote-servers#connecting-to-a-remote-mcp-server). On first connection, Claude Desktop opens your browser to authenticate with Bitrise — no token needed.
 
-In case this feature is not available in your Claude Desktop version, you can use [mcp-remote](https://www.npmjs.com/package/mcp-remote) as an adapter. Add this codeblock to your `claude_desktop_config.json`:
+If your Claude Desktop version doesn't yet support remote MCP servers natively, you can use [mcp-remote](https://www.npmjs.com/package/mcp-remote) as an adapter:
+
+```json
+{
+  "mcpServers": {
+    "bitrise": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://mcp.bitrise.io"
+      ]
+    }
+  }
+}
+```
+
+`mcp-remote` will handle the OAuth flow on your behalf. If your version of `mcp-remote` doesn't yet support OAuth, you can fall back to providing a PAT:
 
 ```json
 {
@@ -94,7 +118,7 @@ In case this feature is not available in your Claude Desktop version, you can us
         "mcp-remote",
         "https://mcp.bitrise.io",
         "--header",
-        "Authorization: YOUR_BITRISE_PAT"
+        "Authorization: Bearer YOUR_BITRISE_PAT"
       ]
     }
   }
@@ -103,7 +127,7 @@ In case this feature is not available in your Claude Desktop version, you can us
 
 Save the config file and restart Claude Desktop. If everything is set up correctly, you should see a hammer icon next to the message composer.
 
-In case `npx` is not found by Claude (`ENOENT`), you can specify the path to the `npx` binary in the `env` section of the configuration like this:
+In case `npx` is not found by Claude (`ENOENT`), specify the path to the `npx` binary in the `env` section:
 
 ```json
 {
@@ -120,7 +144,7 @@ In case `npx` is not found by Claude (`ENOENT`), you can specify the path to the
 
 ### Local Server Setup (Go required)
 
-Add this codeblock to your `claude_desktop_config.json`:
+The local server uses stdio with a Personal Access Token:
 
 ```json
 {
@@ -151,9 +175,9 @@ Add this codeblock to your `claude_desktop_config.json`:
    - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 5. Open the file in a text editor
 6. Paste one of the code blocks above, based on your chosen configuration (remote or local)
-7. Replace `YOUR_BITRISE_PAT` with your actual token or $BITRISE_PAT environment variable
-8. Save the file
-9. Restart Claude Desktop
+7. Save the file
+8. Restart Claude Desktop
+9. If using OAuth: complete the sign-in flow in your browser the first time you use a tool
 
 ### Advanced configuration
 
@@ -161,8 +185,13 @@ See [Tools](/docs/tools.md) for enabling/disabling specific API groups.
 
 ## Troubleshooting
 
+**OAuth flow doesn't open browser:**
+- Make sure your Claude version supports MCP OAuth (recent builds only)
+- Try falling back to PAT-based authentication
+
 **Authentication Failed:**
-- Check token hasn't expired
+- For OAuth: re-authenticate via `/mcp` command in Claude Code, or by deleting and re-adding the server
+- For PAT: check token hasn't expired or been revoked
 
 **Remote Server:**
 - Verify URL: `https://mcp.bitrise.io`
@@ -170,17 +199,15 @@ See [Tools](/docs/tools.md) for enabling/disabling specific API groups.
 **Server Not Starting / Tools Not Showing:**
 - Run `claude mcp list` to view currently configured MCP servers
 - Validate JSON syntax
-- If using an environment variable to store your PAT, make sure you're properly sourcing your PAT using the environment variable
 - Restart Claude Code and check `/mcp` command
 - Delete the Bitrise server by running `claude mcp remove bitrise` and repeating the setup process with a different method
-- Make sure you're running Claude Code within the project you're currently working on to ensure the MCP configuration is properly scoped to your project
 - Check logs:
   - Claude Code: Use `/mcp` command
   - Claude Desktop: `ls ~/Library/Logs/Claude/` and `cat ~/Library/Logs/Claude/mcp-server-*.log` (macOS) or `%APPDATA%\Claude\logs\` (Windows)
 
 ## Important Notes
 
-- Remote server requires Streamable HTTP support (check your Claude version)
+- Remote server requires Streamable HTTP support (check your Claude version). OAuth requires a more recent build than basic Streamable HTTP.
 - Configuration scopes for Claude Code:
   - `-s user`: Available across all projects
   - `-s project`: Shared via `.mcp.json` file

--- a/docs/install-cursor.md
+++ b/docs/install-cursor.md
@@ -2,28 +2,36 @@
 
 ## Prerequisites
 
-1. [Cursor](https://cursor.com/download) IDE installed (latest version)
-2. [Create a Bitrise API Token](https://devcenter.bitrise.io/api/authentication):
-   - Go to your [Bitrise Account Settings/Security](https://app.bitrise.io/me/account/security).
-   - Navigate to the "Personal access tokens" section.
-   - Copy the generated token.
-3. For local setup: [Go](https://go.dev/) (>=1.25) installed
+1. [Cursor](https://cursor.com/download) IDE installed (latest version, with MCP OAuth support — Cursor v0.48.0+ for Streamable HTTP, recent builds for OAuth)
+2. A Bitrise account
+3. For local setup: [Go](https://go.dev/) (>=1.25) installed and a Bitrise PAT
 
 ## Remote Server Setup (Recommended)
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=bitrise&config=eyJ1cmwiOiJodHRwczovL21jcC5iaXRyaXNlLmlvIiwiaGVhZGVycyI6eyJBdXRob3JpemF0aW9uIjoiQmVhcmVyIFlPVVJfQklUUklTRV9QQVQifX0%3D%0A)
-
-Uses Bitrise's hosted server at https://mcp.bitrise.io. Requires Cursor v0.48.0+ for Streamable HTTP support. While Cursor supports OAuth for some MCP servers, the Bitrise server currently requires a Personal Access Token.
+Recent Cursor versions support MCP OAuth — on first tool use Cursor opens your browser to sign in to Bitrise; no token to paste.
 
 ### Install steps
 
-1. Click the install button above and follow the flow, or go directly to your global MCP configuration file at `~/.cursor/mcp.json` and enter the code block below
-2. In Tools & Integrations > MCP tools, click the pencil icon next to "bitrise"
-3. Replace `YOUR_BITRISE_PAT` with your actual [Bitrise Personal Access Token](https://devcenter.bitrise.io/api/authentication)
-4. Save the file
-5. Restart Cursor
+1. Open your global MCP configuration file at `~/.cursor/mcp.json` (or use a project-local `.cursor/mcp.json`) and add the configuration below
+2. Save the file
+3. Restart Cursor
+4. On first tool invocation, complete the browser-based sign-in flow
 
 ### Streamable HTTP Configuration
+
+```json
+{
+  "mcpServers": {
+    "bitrise": {
+      "url": "https://mcp.bitrise.io"
+    }
+  }
+}
+```
+
+### Fallback: PAT-based authentication
+
+If your Cursor version doesn't yet support MCP OAuth, you can use a Personal Access Token. [Create one](https://devcenter.bitrise.io/api/authentication) under [Account Settings → Security](https://app.bitrise.io/me/account/security), then:
 
 ```json
 {
@@ -40,15 +48,15 @@ Uses Bitrise's hosted server at https://mcp.bitrise.io. Requires Cursor v0.48.0+
 
 ## Local Server Setup
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=bitrise&config=eyJlbnYiOnsiQklUUklTRV9UT0tFTiI6IllPVVJfQklUUklTRV9QQVQifSwiY29tbWFuZCI6ImdvIHJ1biBnaXRodWIuY29tL2JpdHJpc2UtaW8vYml0cmlzZS1tY3AvdjJAdjIifQo%3D)
+The local Bitrise MCP server runs via Go and uses a Personal Access Token (stdio mode, no OAuth).
 
-The local Bitrise MCP server runs via Go and requires Go to be installed.
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=bitrise&config=eyJlbnYiOnsiQklUUklTRV9UT0tFTiI6IllPVVJfQklUUklTRV9QQVQifSwiY29tbWFuZCI6ImdvIHJ1biBnaXRodWIuY29tL2JpdHJpc2UtaW8vYml0cmlzZS1tY3AvdjJAdjIifQo%3D)
 
 ### Install steps
 
-1. Click the install button above and follow the flow, or go directly to your global MCP configuration file at `~/.cursor/mcp.json` and enter the code block below
+1. Click the install button above and follow the flow, or open `~/.cursor/mcp.json` and add the configuration below
 2. In Tools & Integrations > MCP tools, click the pencil icon next to "bitrise"
-3. Replace `YOUR_BITRISE_PAT` with your actual [Bitrise Personal Access Token](https://devcenter.bitrise.io/api/authentication)
+3. Replace `YOUR_BITRISE_PAT` with your actual Personal Access Token
 4. Save the file
 5. Restart Cursor
 
@@ -81,7 +89,7 @@ The local Bitrise MCP server runs via Go and requires Go to be installed.
 1. Restart Cursor completely
 2. Check for green dot in Settings → Tools & Integrations → MCP Tools
 3. In chat/composer, check "Available Tools"
-4. Test with: "List my Bitrise apps"
+4. Test with: "List my Bitrise apps" (the first tool call will trigger the OAuth flow if you're not already signed in)
 
 ## Advanced configuration
 
@@ -91,6 +99,7 @@ See [Tools](/docs/tools.md) for enabling/disabling specific API groups.
 
 ### Remote Server Issues
 
+- **OAuth flow doesn't open browser**: Update Cursor to a recent build. Older builds with Streamable HTTP but without OAuth support can use the PAT-based fallback above.
 - **Streamable HTTP not working**: Ensure you're using Cursor v0.48.0 or later
 - **Connection errors**: Check firewall/proxy settings
 

--- a/docs/install-gemini-cli.md
+++ b/docs/install-gemini-cli.md
@@ -3,24 +3,8 @@
 ## Prerequisites
 
 1. The latest version of Google Gemini CLI installed (see [official Gemini CLI documentation](https://github.com/google-gemini/gemini-cli))
-2. [Create a Bitrise API Token](https://devcenter.bitrise.io/api/authentication):
-   - Go to your [Bitrise Account Settings/Security](https://app.bitrise.io/me/account/security).
-   - Navigate to the "Personal access tokens" section.
-   - Copy the generated token.
-3. For local setup: [Go](https://go.dev/) (>=1.25) installed
-
-<details>
-<summary><b>Storing Your PAT Securely</b></summary>
-<br>
-
-For security, avoid hardcoding your token. Create or update `~/.gemini/.env` (where `~` is your home or project directory) with your PAT:
-
-```bash
-# ~/.gemini/.env
-BITRISE_PAT=your_token_here
-```
-
-</details>
+2. A Bitrise account
+3. For local setup: [Go](https://go.dev/) (>=1.25) installed and a Bitrise PAT
 
 ## Bitrise MCP Server Configuration
 
@@ -29,20 +13,38 @@ MCP servers for Gemini CLI are configured in its settings JSON under an `mcpServ
 - **Global configuration**: `~/.gemini/settings.json` where `~` is your home directory
 - **Project-specific**: `.gemini/settings.json` in your project directory
 
-After securely storing your PAT, you can add the Bitrise MCP server configuration to your settings file using one of the methods below. You may need to restart the Gemini CLI for changes to take effect.
+You may need to restart the Gemini CLI for changes to take effect.
 
 ### Method 1: Gemini Extension (Recommended)
 
-The simplest way is to use Bitrise's hosted MCP server via our gemini extension.
+The simplest way is to use Bitrise's hosted MCP server via our Gemini extension:
 
-`gemini extensions install https://github.com/bitrise-io/bitrise-mcp`
+```
+gemini extensions install https://github.com/bitrise-io/bitrise-mcp
+```
 
-> [!NOTE]
-> You will still need to have a personal access token called `BITRISE_PAT` in your environment.
+The extension handles the OAuth flow automatically on first use — you'll be prompted to sign in to Bitrise in your browser.
 
 ### Method 2: Remote Server
 
-You can also connect to the hosted MCP server directly. After securely storing your PAT, configure Gemini CLI with:
+You can also connect to the hosted MCP server directly:
+
+```json
+// ~/.gemini/settings.json
+{
+    "mcpServers": {
+        "bitrise": {
+            "httpUrl": "https://mcp.bitrise.io"
+        }
+    }
+}
+```
+
+On first tool use, Gemini CLI will open your browser for the Bitrise OAuth sign-in.
+
+#### Fallback: PAT-based authentication
+
+For Gemini CLI builds that don't yet support MCP OAuth, [create a Bitrise PAT](https://devcenter.bitrise.io/api/authentication) and pass it as a header:
 
 ```json
 // ~/.gemini/settings.json
@@ -58,7 +60,22 @@ You can also connect to the hosted MCP server directly. After securely storing y
 }
 ```
 
+<details>
+<summary><b>Storing Your PAT Securely</b></summary>
+<br>
+
+For security, avoid hardcoding your token. Create or update `~/.gemini/.env` (where `~` is your home or project directory) with your PAT:
+
+```bash
+# ~/.gemini/.env
+BITRISE_PAT=your_token_here
+```
+
+</details>
+
 ### Method 3: Local Server Setup (Go Required)
+
+The local server uses stdio with a Personal Access Token:
 
 ```json
 // ~/.gemini/settings.json
@@ -103,6 +120,8 @@ To verify that the Bitrise MCP server has been configured, start Gemini CLI in y
     List my Bitrise apps
     ```
 
+    The first tool call will trigger the OAuth sign-in flow if you're using the remote server without a PAT.
+
 ## Advanced configuration
 
 See [Tools](/docs/tools.md) for enabling/disabling specific API groups.
@@ -113,7 +132,8 @@ You can find more MCP configuration options for Gemini CLI here: [MCP Configurat
 
 ### Authentication Issues
 
-- **Token expired**: Generate a new Bitrise token
+- **OAuth flow doesn't open**: Update Gemini CLI to a recent build, or fall back to PAT-based auth
+- **Token expired (PAT)**: Generate a new Bitrise token
 
 ### Configuration Issues
 

--- a/docs/install-kiro.md
+++ b/docs/install-kiro.md
@@ -2,10 +2,12 @@
 
 ## Prerequisites
 - AWS Kiro IDE installed
-- [Create a Bitrise API Token](https://devcenter.bitrise.io/api/authentication):
-  - Go to your [Bitrise Account Settings/Security](https://app.bitrise.io/me/account/security)
-  - Navigate to the "Personal access tokens" section
-  - Copy the generated token
+
+## Authentication
+
+Kiro currently uses environment-variable-based authentication for MCP servers, so the standard Power installation uses a Bitrise Personal Access Token (PAT). [Create a Bitrise API Token](https://devcenter.bitrise.io/api/authentication) under [Account Settings → Security](https://app.bitrise.io/me/account/security).
+
+If you're running a Kiro build that supports MCP OAuth and prefer to use it, see the [OAuth-based Kiro configuration](#oauth-based-configuration-experimental) section below.
 
 ## Installation via Kiro Power
 
@@ -20,7 +22,6 @@ AWS Kiro supports installing the Bitrise MCP server as a Power, which provides a
    - Click on "Add power from GitHub"
 
 3. **Enter the Repository URL**
-   - Enter the following URL:
    ```
    https://github.com/bitrise-io/bitrise-mcp/tree/main/kiro-powers/bitrise-ci
    ```
@@ -50,6 +51,23 @@ Once installed, the Bitrise Power will automatically activate when relevant. You
 - Set up release management
 
 The power provides access to all 63 Bitrise tools. For a complete list of available tools and their parameters, refer to the [tools documentation](/docs/tools.md).
+
+## OAuth-based Configuration (experimental)
+
+For Kiro builds that support MCP OAuth, you can drop the `BITRISE_TOKEN` requirement entirely. Edit `~/.kiro/settings/mcp.json` (user level) or `.kiro/settings/mcp.json` (workspace level) and remove the `headers` block:
+
+```json
+{
+  "mcpServers": {
+    "bitrise": {
+      "type": "http",
+      "url": "https://mcp.bitrise.io"
+    }
+  }
+}
+```
+
+On first tool use, Kiro will open your browser for the Bitrise sign-in flow.
 
 ## Advanced Configuration
 
@@ -92,6 +110,9 @@ If the environment variable approach doesn't work, you can hardcode the token:
 2. Find the Bitrise server entry
 3. Replace `${BITRISE_TOKEN}` with your actual token value
 4. Save the file and restart Kiro
+
+**Option 3: Use OAuth**
+If your Kiro build supports MCP OAuth, see the [OAuth-based Configuration](#oauth-based-configuration-experimental) section above.
 
 **Note on Environment Variable Syntax**
 The syntax for environment variables differs between Kiro CLI and IDE:

--- a/docs/install-other-copilot-ides.md
+++ b/docs/install-other-copilot-ides.md
@@ -6,11 +6,9 @@ Quick setup guide for the Bitrise MCP server in GitHub Copilot across different 
 1. GitHub Copilot License: Any Copilot plan (Free, Pro, Pro+, Business, Enterprise) for Copilot access
 2. Bitrise Account: Bitrise account for Bitrise MCP server access
 3. MCP Servers in Copilot Policy: Organizations assigning Copilot seats must enable this policy for all MCP access in Copilot for VS Code and Copilot Coding Agent – all other Copilot IDEs will migrate to this policy in the coming months
-4. [Create a Bitrise API Token](https://devcenter.bitrise.io/api/authentication):
-   - Go to your [Bitrise Account Settings/Security](https://app.bitrise.io/me/account/security).
-   - Navigate to the "Personal access tokens" section.
-   - Copy the generated token.
-5. For local setup: [Go](https://go.dev/) (>=1.23) installed
+4. For local setup: [Go](https://go.dev/) (>=1.23) installed and a Bitrise Personal Access Token
+
+The remote setups below use OAuth — your IDE opens a browser on first tool use, you sign in to Bitrise, no token to paste. For older Copilot IDE builds without MCP OAuth, a PAT-based fallback configuration is included for each IDE.
 
 ## Visual Studio
 
@@ -27,6 +25,21 @@ The remote Bitrise MCP server is hosted by Bitrise and provides automatic update
 {
   "servers": {
     "bitrise": {
+      "url": "https://mcp.bitrise.io"
+    }
+  }
+}
+```
+3. Save the file. Wait for CodeLens to update to offer a way to authenticate to the new server, activate that and complete the Bitrise sign-in in your browser.
+4. In the GitHub Copilot Chat window, switch to Agent mode.
+5. Activate the tool picker in the Chat window and enable one or more tools from the "bitrise" MCP server.
+
+#### Fallback: PAT-based authentication
+
+```json
+{
+  "servers": {
+    "bitrise": {
       "url": "https://mcp.bitrise.io",
       "headers": {
         "Authorization": "Bearer YOUR_BITRISE_PAT"
@@ -35,13 +48,10 @@ The remote Bitrise MCP server is hosted by Bitrise and provides automatic update
   }
 }
 ```
-3. Save the file. Wait for CodeLens to update to offer a way to authenticate to the new server, activate that and pick the Bitrise account to authenticate with.
-4. In the GitHub Copilot Chat window, switch to Agent mode.
-5. Activate the tool picker in the Chat window and enable one or more tools from the "bitrise" MCP server.
+
+[Create a PAT](https://devcenter.bitrise.io/api/authentication) under [Account Settings → Security](https://app.bitrise.io/me/account/security).
 
 ### Local Server (Go required)
-
-For users who prefer to run the Bitrise MCP server locally.
 
 #### Configuration
 1. Create an `.mcp.json` file in your solution or %USERPROFILE% directory.
@@ -72,12 +82,23 @@ Agent mode and MCP support available in public preview across IntelliJ IDEA, PyC
 
 ### Remote Server (Recommended)
 
-The remote Bitrise MCP server is hosted by Bitrise and provides automatic updates with no local setup required.
-
 #### Configuration Steps
 1. Install/update the GitHub Copilot plugin
 2. Click **GitHub Copilot icon in the status bar** → **Edit Settings** → **Model Context Protocol** → **Configure**
 3. Add configuration:
+```json
+{
+  "servers": {
+    "bitrise": {
+      "url": "https://mcp.bitrise.io"
+    }
+  }
+}
+```
+4. Press `Ctrl + S` or `Command + S` to save, or close the `mcp.json` file. On first tool use the IDE will open your browser for Bitrise sign-in.
+
+#### Fallback: PAT-based authentication
+
 ```json
 {
   "servers": {
@@ -92,13 +113,9 @@ The remote Bitrise MCP server is hosted by Bitrise and provides automatic update
   }
 }
 ```
-4. Press `Ctrl + S` or `Command + S` to save, or close the `mcp.json` file. The configuration should take effect immediately and restart all the MCP servers defined. You can restart the IDE if needed.
 
 ### Local Server (Go required)
 
-For users who prefer to run the Bitrise MCP server locally.
-
-#### Configuration
 ```json
 {
   "servers": {
@@ -124,12 +141,23 @@ Agent mode and MCP support now available in public preview for Xcode.
 
 ### Remote Server (Recommended)
 
-The remote Bitrise MCP server is hosted by Bitrise and provides automatic updates with no local setup required.
-
 #### Configuration Steps
 1. Install/update [GitHub Copilot for Xcode](https://github.com/github/CopilotForXcode)
 2. Open **GitHub Copilot for Xcode app** → **Agent Mode** → **🛠️ Tool Picker** → **Edit Config**
 3. Configure your MCP servers:
+```json
+{
+  "servers": {
+    "bitrise": {
+      "url": "https://mcp.bitrise.io"
+    }
+  }
+}
+```
+4. On first tool use, complete the Bitrise sign-in flow in your browser.
+
+#### Fallback: PAT-based authentication
+
 ```json
 {
   "servers": {
@@ -147,9 +175,6 @@ The remote Bitrise MCP server is hosted by Bitrise and provides automatic update
 
 ### Local Server (Go required)
 
-For users who prefer to run the Bitrise MCP server locally.
-
-#### Configuration
 ```json
 {
   "servers": {
@@ -175,12 +200,23 @@ MCP support available with Eclipse 2024-03+ and latest version of the GitHub Cop
 
 ### Remote Server (Recommended)
 
-The remote Bitrise MCP server is hosted by Bitrise and provides automatic updates with no local setup required.
-
 #### Configuration Steps
 1. Install GitHub Copilot extension from Eclipse Marketplace
 2. Click the **GitHub Copilot icon** → **Edit Preferences** → **MCP** (under **GitHub Copilot**)
 3. Add Bitrise MCP server configuration:
+```json
+{
+  "servers": {
+    "bitrise": {
+      "url": "https://mcp.bitrise.io"
+    }
+  }
+}
+```
+4. Click the "Apply and Close" button. On first tool use, complete the Bitrise sign-in in your browser.
+
+#### Fallback: PAT-based authentication
+
 ```json
 {
   "servers": {
@@ -195,13 +231,9 @@ The remote Bitrise MCP server is hosted by Bitrise and provides automatic update
   }
 }
 ```
-4. Click the "Apply and Close" button in the preference dialog and the configuration will take effect automatically.
 
 ### Local Server (Go required)
 
-For users who prefer to run the Bitrise MCP server locally.
-
-#### Configuration
 ```json
 {
   "servers": {
@@ -227,7 +259,7 @@ For users who prefer to run the Bitrise MCP server locally.
 After setup:
 1. Restart your IDE completely
 2. Open Agent mode in Copilot Chat
-3. Try: *"List my Bitrise apps"*
+3. Try: *"List my Bitrise apps"* — first call triggers OAuth sign-in for the remote server
 4. Copilot can now access Bitrise data and perform operations
 
 ## Advanced configuration
@@ -236,6 +268,7 @@ See [Tools](/docs/tools.md) for enabling/disabling specific API groups.
 
 ## Troubleshooting
 
+- **OAuth flow doesn't open browser**: Make sure your Copilot integration is on a build that supports MCP OAuth. Fall back to PAT-based auth in older versions.
 - **Connection issues**: Verify IDE version compatibility
 - **Authentication errors**: Check if your organization has enabled the MCP policy for Copilot
 - **Tools not appearing**: Restart IDE after configuration changes and check error logs

--- a/docs/install-vscode.md
+++ b/docs/install-vscode.md
@@ -1,68 +1,84 @@
 # Install Bitrise MCP Server in VS Code
 
 ## Prerequisites
-- [VS Code](https://code.visualstudio.com/Download) installed
-- [Create a Bitrise API Token](https://devcenter.bitrise.io/api/authentication):
-   - Go to your [Bitrise Account Settings/Security](https://app.bitrise.io/me/account/security).
-   - Navigate to the "Personal access tokens" section.
-   - Copy the generated token.
-- For local setup: [Go](https://go.dev/) (>=1.25) installed
+- [VS Code](https://code.visualstudio.com/Download) installed (recent version, with MCP OAuth support)
+- A Bitrise account
+- For local setup: [Go](https://go.dev/) (>=1.25) installed and a Bitrise PAT
 
-## Remote Server Setup (Streamable HTTP)
+## Remote Server Setup (Streamable HTTP) — Recommended
 
-Follow [VS Code | Add an MCP server](https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server) and add the following configuration to your settings:
+VS Code's MCP integration handles OAuth automatically. On first connection it'll open your browser to sign you in to Bitrise — no token needed.
+
+Follow [VS Code | Add an MCP server](https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server) and add the following to your settings:
 
 ```json
 {
-	"servers": {
-		"bitrise": {
-			"type": "http",
-			"url": "https://mcp.bitrise.io",
-			"headers": {
-			  "Authorization": "Bearer ${input:bitrise-token}"
-			}
-		}
-	},
-	"inputs": [
-		{
-			"id": "bitrise-token",
-			"type": "promptString",
-			"description": "Bitrise token",
-			"password": true
-		}
-	]
+  "servers": {
+    "bitrise": {
+      "type": "http",
+      "url": "https://mcp.bitrise.io"
+    }
+  }
 }
 ```
 
-Save the configuration. VS Code will automatically recognize the change and load the tools into Copilot Chat.
+Save the configuration. VS Code will recognize the change, prompt you to sign in via your browser on first tool use, and load the tools into Copilot Chat.
 
-## Local Server Setup (Go required)
+### Fallback: PAT-based authentication
 
-Do the same as above, but use the following configuration instead:
+If your VS Code build doesn't support MCP OAuth yet, you can use a Personal Access Token:
 
 ```json
 {
-	"servers": {
-		"bitrise-local": {
-			"type": "stdio",
-			"command": "go",
-			"args": [
-				"run",
-				"github.com/bitrise-io/bitrise-mcp/v2@v2"
-			],
-			"env": {
-				"BITRISE_TOKEN": "${input:bitrise-token}"
-			}
-		}
-	},
-	"inputs": [
-		{
-			"id": "bitrise-token",
-			"type": "promptString",
-			"description": "Bitrise token",
-			"password": true
-		}
-	]
+  "servers": {
+    "bitrise": {
+      "type": "http",
+      "url": "https://mcp.bitrise.io",
+      "headers": {
+        "Authorization": "Bearer ${input:bitrise-token}"
+      }
+    }
+  },
+  "inputs": [
+    {
+      "id": "bitrise-token",
+      "type": "promptString",
+      "description": "Bitrise token",
+      "password": true
+    }
+  ]
+}
+```
+
+[Create a Bitrise API Token](https://devcenter.bitrise.io/api/authentication) under [Account Settings → Security](https://app.bitrise.io/me/account/security) when prompted.
+
+## Local Server Setup (Go required)
+
+Local stdio mode authenticates with a Personal Access Token:
+
+```json
+{
+  "servers": {
+    "bitrise-local": {
+      "type": "stdio",
+      "command": "go",
+      "args": [
+        "run",
+        "github.com/bitrise-io/bitrise-mcp/v2@v2"
+      ],
+      "env": {
+        "BITRISE_TOKEN": "${input:bitrise-token}"
+      }
+    }
+  },
+  "inputs": [
+    {
+      "id": "bitrise-token",
+      "type": "promptString",
+      "description": "Bitrise token",
+      "password": true
+    }
+  ]
 }
 ```
 

--- a/docs/install-windsurf.md
+++ b/docs/install-windsurf.md
@@ -2,18 +2,28 @@
 
 ## Prerequisites
 1. [Windsurf IDE](https://windsurf.com/) installed (latest version)
-2. [Create a Bitrise API Token](https://devcenter.bitrise.io/api/authentication):
-   - Go to your [Bitrise Account Settings/Security](https://app.bitrise.io/me/account/security).
-   - Navigate to the "Personal access tokens" section.
-   - Copy the generated token.
-3. For local setup: [Go](https://go.dev/) (>=1.25) installed
+2. A Bitrise account
+3. For local setup: [Go](https://go.dev/) (>=1.25) installed and a Bitrise PAT
 
 ## Remote Server Setup (Recommended)
 
-The remote Bitrise MCP server is hosted by Bitrise at `https://mcp.bitrise.io` and supports Streamable HTTP protocol.
+The remote Bitrise MCP server is hosted by Bitrise at `https://mcp.bitrise.io` and supports Streamable HTTP. Recent Windsurf builds support MCP OAuth — the first tool use opens your browser to sign in to Bitrise; no token to paste.
 
 ### Streamable HTTP Configuration
-Windsurf supports Streamable HTTP servers with a `serverUrl` field:
+
+```json
+{
+  "mcpServers": {
+    "bitrise": {
+      "serverUrl": "https://mcp.bitrise.io"
+    }
+  }
+}
+```
+
+### Fallback: PAT-based authentication
+
+If your Windsurf build doesn't yet support MCP OAuth, [create a Bitrise PAT](https://devcenter.bitrise.io/api/authentication) under [Account Settings → Security](https://app.bitrise.io/me/account/security) and add it as a header:
 
 ```json
 {
@@ -55,6 +65,7 @@ Windsurf supports Streamable HTTP servers with a `serverUrl` field:
 3. Add your chosen configuration from above
 4. Save the file
 5. Click **Refresh** (🔄) in the MCP toolbar
+6. On the first tool call, complete the browser-based sign-in flow (OAuth setup only)
 
 ## Configuration Details
 
@@ -67,7 +78,7 @@ Windsurf supports Streamable HTTP servers with a `serverUrl` field:
 After installation:
 1. Look for "1 available MCP server" in the MCP toolbar
 2. Click the hammer icon to see available Bitrise tools
-3. Test with: "List my Bitrise apps"
+3. Test with: "List my Bitrise apps" (first call triggers OAuth sign-in if using the remote server)
 4. Check for green dot next to the server name
 
 ## Advanced configuration
@@ -77,7 +88,8 @@ See [Tools](/docs/tools.md) for enabling/disabling specific API groups.
 ## Troubleshooting
 
 ### Remote Server Issues
-- **Authentication failures**: Verify PAT hasn't expired
+- **OAuth flow doesn't open browser**: Update Windsurf to a recent build. Fall back to PAT-based auth in older versions.
+- **Authentication failures (PAT)**: Verify the PAT hasn't expired or been revoked
 - **Connection errors**: Check firewall/proxy settings for HTTPS connections
 - **Streamable HTTP not working**: Ensure you're using the correct `serverUrl` field format
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -4,10 +4,7 @@
 	"mcpServers": {
 		"bitrise": {
 			"description": "Connect AI assistants to Bitrise - manage apps, builds, artifacts, and more through natural language",
-			"httpUrl": "https://mcp.bitrise.io",
-			"headers": {
-				"Authorization": "Bearer $BITRISE_PAT"
-			}
+			"httpUrl": "https://mcp.bitrise.io"
 		}
 	}
 }

--- a/server.json
+++ b/server.json
@@ -11,8 +11,8 @@
       "headers": [
         {
           "name": "Authorization",
-          "description": "Bitrise Personal Access Token (format: 'Bearer YOUR_TOKEN'). Get your token from https://app.bitrise.io/me/account/security",
-          "isRequired": true,
+          "description": "Optional. Bitrise Personal Access Token (format: 'Bearer YOUR_TOKEN') for MCP clients that don't yet support OAuth. Get your token from https://app.bitrise.io/me/account/security. Modern MCP clients (Claude, Cursor, VS Code, etc.) can leave this unset and the server will trigger the OAuth flow automatically on first tool use.",
+          "isRequired": false,
           "isSecret": true
         },
         {


### PR DESCRIPTION
The hosted MCP server now supports OAuth, so users shouldn't need to copy a PAT for the common case.

- Remote setups across all install guides: drop the required `Authorization: Bearer <PAT>` header. Just point at `https://mcp.bitrise.io`, browser opens for sign-in on first tool use.
- PAT-based config kept as a "Fallback" subsection in each guide for clients that don't speak MCP OAuth yet.
- Local stdio setups unchanged — still use `BITRISE_TOKEN`.
- Kiro: PAT stays primary since the Power's `mcp.json` is a published artifact; OAuth is documented as an "experimental" override.