### PR TITLE
[CI-6162] Intent-optimize MCP registry description

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"mcpServers": {
 		"bitrise": {
-			"description": "Connect AI assistants to Bitrise - manage apps, builds, artifacts, and more through natural language",
+			"description": "Set up & manage mobile CI/CD on Bitrise: build, test, distribute iOS, Android, Flutter, RN apps.",
 			"httpUrl": "https://mcp.bitrise.io"
 		}
 	}

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.bitrise-io/bitrise-mcp",
   "title": "Bitrise",
-  "description": "MCP Server for Bitrise, enabling app management, build operations, artifact management, and more.",
+  "description": "Set up & manage mobile CI/CD on Bitrise: build, test, distribute iOS, Android, Flutter, RN apps.",
   "version": "",
   "remotes": [
     {


### PR DESCRIPTION
## What

Intent-optimize the MCP server `description` so a cold agent searching the [MCP community registry](https://registry.modelcontextprotocol.io) for mobile-CI intent ("mobile CI", "iOS CI", "Android CI", "distribute app") surfaces the Bitrise server. The current description carries zero intent keywords.

| | description |
|---|---|
| Before | `MCP Server for Bitrise, enabling app management, build operations, artifact management, and more.` |
| After | `Set up & manage mobile CI/CD on Bitrise: build, test, distribute iOS, Android, Flutter, RN apps.` |

## Changes

- **`server.json`** — new `description` (96 chars, under the registry's 100-char hard limit). `title: "Bitrise"` and the empty `version` (injected from the tag at publish time) are unchanged. Server `name` / registry identity untouched.
- **`gemini-extension.json`** — mirrored the identical string so the description stays single-sourced (no drift between surfaces).
