### PR TITLE
Return 401 + WWW-Authenticate for unauthenticated tool calls

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -16,18 +16,35 @@ import (
 	"go.uber.org/zap"
 )
 
+// protectedResourceMetadataPath is the well-known location (RFC 9728) where the
+// server advertises which authorization server issues tokens for this resource.
+const protectedResourceMetadataPath = "/.well-known/oauth-protected-resource"
+
+// serverBaseURL reconstructs this server's externally visible base URL from the
+// incoming request, honouring the X-Forwarded-Proto header set by TLS-terminating
+// proxies.
+func serverBaseURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
+		scheme = "https"
+	}
+	return scheme + "://" + r.Host
+}
+
+// resourceMetadataURL returns the absolute URL of this server's RFC 9728
+// protected resource metadata document, derived from the incoming request so it
+// stays correct regardless of the host the server is reached on.
+func resourceMetadataURL(r *http.Request) string {
+	return serverBaseURL(r) + protectedResourceMetadataPath
+}
+
 // oauthProtectedResourceHandler serves RFC 9728 Protected Resource Metadata,
 // telling OAuth clients which authorization server issues tokens for this resource.
 func oauthProtectedResourceHandler(issuer string) http.HandlerFunc {
 	issuer = strings.TrimRight(issuer, "/")
 	return func(w http.ResponseWriter, r *http.Request) {
-		scheme := "http"
-		if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
-			scheme = "https"
-		}
-		serverBase := scheme + "://" + r.Host
 		metadata := map[string]any{
-			"resource":                 serverBase,
+			"resource":                 serverBaseURL(r),
 			"authorization_servers":    []string{issuer},
 			"bearer_methods_supported": []string{"header"},
 		}
@@ -36,6 +53,21 @@ func oauthProtectedResourceHandler(issuer string) http.HandlerFunc {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(body)
 	}
+}
+
+// extractPAT resolves the Authorization bearer token on r into a Bitrise PAT,
+// exchanging it via the OIDC token endpoint (RFC 8693) when it looks like a JWT
+// and an exchanger is configured. It returns an empty PAT and a nil error when
+// no bearer token is present.
+func extractPAT(r *http.Request, exchanger *jwtExchanger) (string, error) {
+	token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if token == "" {
+		return "", nil
+	}
+	if exchanger != nil && isJWT(token) {
+		return exchanger.exchange(r.Context(), token)
+	}
+	return token, nil
 }
 
 type cacheEntry struct {

--- a/main.go
+++ b/main.go
@@ -179,22 +179,24 @@ func runHTTPTransport(mcpServer *server.MCPServer, logger *zap.SugaredLogger, cf
 		exchanger = &jwtExchanger{tokenEndpoint: cfg.OIDCTokenEndpoint, logger: logger}
 	}
 
+	// When an external OAuth issuer is configured the auth middleware enforces
+	// authentication for tool calls (returning a 401 + WWW-Authenticate) and
+	// resolves the bearer token to a PAT before the request reaches the MCP
+	// handler. Otherwise the context func resolves it here, preserving the
+	// previous behaviour where missing auth surfaces as an in-band tool error.
+	authActive := cfg.ExternalOAuthIssuer != ""
+
 	mcpHandler := server.NewStreamableHTTPServer(
 		mcpServer,
 		server.WithStateLess(true),
 		server.WithHTTPContextFunc(func(ctx context.Context, r *http.Request) context.Context {
-			token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
-			if token != "" {
-				pat := token
-				if exchanger != nil && isJWT(token) {
-					var err error
-					pat, err = exchanger.exchange(r.Context(), token)
-					if err != nil {
-						logger.Warnw("JWT→PAT exchange failed", "error", err)
-						return ctx
-					}
+			if !authActive {
+				pat, err := extractPAT(r, exchanger)
+				if err != nil {
+					logger.Warnw("JWT→PAT exchange failed", "error", err)
+				} else if pat != "" {
+					ctx = bitrise.ContextWithPAT(ctx, pat)
 				}
-				ctx = bitrise.ContextWithPAT(ctx, pat)
 			}
 			// server.WithToolFilter can use it to limit the tools listed.
 			enabledGroups := r.Header.Get("x-bitrise-enabled-api-groups")
@@ -221,8 +223,13 @@ func runHTTPTransport(mcpServer *server.MCPServer, logger *zap.SugaredLogger, cf
 	}
 	mux.HandleFunc("/readyz", readyzHandler)
 	mux.HandleFunc("/livez", livezHandler)
-	if cfg.ExternalOAuthIssuer != "" {
-		mux.HandleFunc("/.well-known/oauth-protected-resource", oauthProtectedResourceHandler(cfg.ExternalOAuthIssuer))
+	if authActive {
+		mux.HandleFunc(protectedResourceMetadataPath, oauthProtectedResourceHandler(cfg.ExternalOAuthIssuer))
+	}
+
+	var mcpEntry http.Handler = mcpHandler
+	if authActive {
+		mcpEntry = requireAuthMiddleware(mcpHandler, exchanger, logger)
 	}
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// If the request looks like it's from a browser (Sec-Fetch-Mode: navigate),
@@ -232,7 +239,7 @@ func runHTTPTransport(mcpServer *server.MCPServer, logger *zap.SugaredLogger, cf
 			return
 		}
 		// Otherwise, handle as MCP request
-		mcpHandler.ServeHTTP(w, r)
+		mcpEntry.ServeHTTP(w, r)
 	})
 
 	httpServer := &http.Server{

--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/bitrise-io/bitrise-mcp/v2/internal/bitrise"
+	"github.com/mark3labs/mcp-go/mcp"
+	"go.uber.org/zap"
+)
+
+// requireAuthMiddleware gates tool-executing MCP requests behind a valid bearer
+// token. When a tools/call arrives without usable credentials it responds with
+// an RFC 6750 401 whose WWW-Authenticate header points at this server's RFC 9728
+// protected resource metadata. That 401 is the signal a spec-compliant reactive
+// OAuth client waits for before starting its authorization flow; without it such
+// clients connect and list tools fine but can never authenticate to run them.
+//
+// initialize and tools/list are intentionally left open so clients can connect
+// and enumerate tools before authorizing. The middleware is only installed when
+// an external OAuth issuer is configured; otherwise the server keeps its prior
+// behaviour of surfacing missing auth as an in-band tool error.
+func requireAuthMiddleware(next http.Handler, exchanger *jwtExchanger, logger *zap.SugaredLogger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only POST carries JSON-RPC requests; GET/DELETE manage the SSE stream
+		// and session and never execute tools.
+		if r.Method != http.MethodPost {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		method, body := peekMCPMethod(r)
+		r.Body = body
+		if !methodRequiresAuth(method) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		pat, err := extractPAT(r, exchanger)
+		if err != nil {
+			// A bearer token was supplied but the JWT→PAT exchange rejected it
+			// (e.g. expired or invalid token): treat it as unauthenticated.
+			logger.Warnw("JWT→PAT exchange failed", "error", err)
+			writeUnauthorized(w, r)
+			return
+		}
+		if pat == "" {
+			writeUnauthorized(w, r)
+			return
+		}
+
+		next.ServeHTTP(w, r.WithContext(bitrise.ContextWithPAT(r.Context(), pat)))
+	})
+}
+
+// peekMCPMethod reads the JSON-RPC method from the request body without
+// consuming it, returning the method and a fresh body for downstream handlers.
+// A body that is missing, unreadable, or not a single JSON-RPC object yields an
+// empty method, which is treated as not requiring auth so the streamable HTTP
+// server can produce its own parse error.
+func peekMCPMethod(r *http.Request) (mcp.MCPMethod, io.ReadCloser) {
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		return "", io.NopCloser(bytes.NewReader(nil))
+	}
+	var msg struct {
+		Method mcp.MCPMethod `json:"method"`
+	}
+	_ = json.Unmarshal(raw, &msg)
+	return msg.Method, io.NopCloser(bytes.NewReader(raw))
+}
+
+// methodRequiresAuth reports whether an MCP method executes a tool and therefore
+// needs Bitrise credentials. Only tools/call does.
+func methodRequiresAuth(method mcp.MCPMethod) bool {
+	return method == mcp.MethodToolsCall
+}
+
+// writeUnauthorized emits an RFC 6750 401 whose WWW-Authenticate header points
+// OAuth clients at this server's RFC 9728 protected resource metadata.
+func writeUnauthorized(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("WWW-Authenticate", fmt.Sprintf("Bearer resource_metadata=%q", resourceMetadataURL(r)))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+	_, _ = w.Write([]byte(`{"error":"unauthorized","error_description":"authentication required to call tools"}`))
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestMethodRequiresAuth(t *testing.T) {
+	cases := map[string]struct {
+		method mcp.MCPMethod
+		want   bool
+	}{
+		"tools/call requires auth":      {method: mcp.MethodToolsCall, want: true},
+		"initialize is open":            {method: mcp.MethodInitialize, want: false},
+		"tools/list is open":            {method: mcp.MethodToolsList, want: false},
+		"ping is open":                  {method: mcp.MethodPing, want: false},
+		"empty/unparseable method open": {method: "", want: false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, methodRequiresAuth(tc.method))
+		})
+	}
+}
+
+func TestExtractPAT(t *testing.T) {
+	nopLogger := zap.NewNop().Sugar()
+
+	t.Run("no Authorization header returns empty PAT and no error", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		pat, err := extractPAT(req, nil)
+		assert.NoError(t, err)
+		assert.Empty(t, pat)
+	})
+
+	t.Run("raw PAT bearer token is returned verbatim", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set("Authorization", "Bearer my-bitrise-pat")
+		pat, err := extractPAT(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "my-bitrise-pat", pat)
+	})
+
+	t.Run("JWT bearer token is exchanged for a PAT", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			body, _ := json.Marshal(map[string]string{"access_token": "exchanged-pat"})
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+		}))
+		defer srv.Close()
+
+		exchanger := &jwtExchanger{tokenEndpoint: srv.URL, logger: nopLogger}
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set("Authorization", "Bearer "+makeTestJWT(time.Now().Add(10*time.Minute).Unix()))
+		pat, err := extractPAT(req, exchanger)
+		assert.NoError(t, err)
+		assert.Equal(t, "exchanged-pat", pat)
+	})
+
+	t.Run("failed JWT exchange surfaces an error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+
+		exchanger := &jwtExchanger{tokenEndpoint: srv.URL, logger: nopLogger}
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set("Authorization", "Bearer "+makeTestJWT(time.Now().Add(10*time.Minute).Unix()))
+		_, err := extractPAT(req, exchanger)
+		assert.Error(t, err)
+	})
+
+	t.Run("JWT without configured exchanger is passed through as-is", func(t *testing.T) {
+		jwt := makeTestJWT(time.Now().Add(10 * time.Minute).Unix())
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set("Authorization", "Bearer "+jwt)
+		pat, err := extractPAT(req, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, jwt, pat)
+	})
+}
+
+// jsonRPCBody builds a minimal JSON-RPC request body for the given method.
+func jsonRPCBody(method mcp.MCPMethod) string {
+	return fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":%q,"params":{}}`, string(method))
+}
+
+// newMCPRequest builds an MCP POST request for the given method with an optional
+// bearer token.
+func newMCPRequest(method mcp.MCPMethod, bearer string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(jsonRPCBody(method)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Host = "mcp.example.com"
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	return req
+}
+
+func TestRequireAuthMiddleware(t *testing.T) {
+	nopLogger := zap.NewNop().Sugar()
+
+	// spyHandler records whether it was reached and what body it observed.
+	type spy struct {
+		called bool
+		body   string
+	}
+	newSpy := func(s *spy) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			s.called = true
+			b, _ := io.ReadAll(r.Body)
+			s.body = string(b)
+			w.WriteHeader(http.StatusOK)
+		})
+	}
+
+	t.Run("unauthenticated tools/call returns 401 with WWW-Authenticate", func(t *testing.T) {
+		s := &spy{}
+		mw := requireAuthMiddleware(newSpy(s), nil, nopLogger)
+
+		req := newMCPRequest(mcp.MethodToolsCall, "")
+		w := httptest.NewRecorder()
+		mw.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.Equal(t,
+			`Bearer resource_metadata="http://mcp.example.com/.well-known/oauth-protected-resource"`,
+			w.Header().Get("WWW-Authenticate"),
+		)
+		assert.False(t, s.called, "downstream handler must not run for unauthenticated tool calls")
+	})
+
+	t.Run("WWW-Authenticate uses https behind a TLS-terminating proxy", func(t *testing.T) {
+		s := &spy{}
+		mw := requireAuthMiddleware(newSpy(s), nil, nopLogger)
+
+		req := newMCPRequest(mcp.MethodToolsCall, "")
+		req.Header.Set("X-Forwarded-Proto", "https")
+		w := httptest.NewRecorder()
+		mw.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.Equal(t,
+			`Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"`,
+			w.Header().Get("WWW-Authenticate"),
+		)
+	})
+
+	t.Run("tools/call with a valid PAT reaches the handler", func(t *testing.T) {
+		s := &spy{}
+		mw := requireAuthMiddleware(newSpy(s), nil, nopLogger)
+
+		req := newMCPRequest(mcp.MethodToolsCall, "valid-pat")
+		w := httptest.NewRecorder()
+		mw.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.True(t, s.called, "downstream handler should run for authenticated tool calls")
+		assert.Equal(t, jsonRPCBody(mcp.MethodToolsCall), s.body, "request body must be preserved for the handler")
+	})
+
+	t.Run("tools/call with a valid JWT is exchanged then reaches the handler", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			body, _ := json.Marshal(map[string]string{"access_token": "exchanged-pat"})
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+		}))
+		defer srv.Close()
+
+		s := &spy{}
+		exchanger := &jwtExchanger{tokenEndpoint: srv.URL, logger: nopLogger}
+		mw := requireAuthMiddleware(newSpy(s), exchanger, nopLogger)
+
+		req := newMCPRequest(mcp.MethodToolsCall, makeTestJWT(time.Now().Add(10*time.Minute).Unix()))
+		w := httptest.NewRecorder()
+		mw.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.True(t, s.called)
+	})
+
+	t.Run("tools/call with an invalid JWT returns 401", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+
+		s := &spy{}
+		exchanger := &jwtExchanger{tokenEndpoint: srv.URL, logger: nopLogger}
+		mw := requireAuthMiddleware(newSpy(s), exchanger, nopLogger)
+
+		req := newMCPRequest(mcp.MethodToolsCall, makeTestJWT(time.Now().Add(10*time.Minute).Unix()))
+		w := httptest.NewRecorder()
+		mw.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.NotEmpty(t, w.Header().Get("WWW-Authenticate"))
+		assert.False(t, s.called)
+	})
+
+	t.Run("initialize is allowed without auth", func(t *testing.T) {
+		s := &spy{}
+		mw := requireAuthMiddleware(newSpy(s), nil, nopLogger)
+
+		req := newMCPRequest(mcp.MethodInitialize, "")
+		w := httptest.NewRecorder()
+		mw.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.True(t, s.called)
+		assert.Empty(t, w.Header().Get("WWW-Authenticate"))
+	})
+
+	t.Run("tools/list is allowed without auth", func(t *testing.T) {
+		s := &spy{}
+		mw := requireAuthMiddleware(newSpy(s), nil, nopLogger)
+
+		req := newMCPRequest(mcp.MethodToolsList, "")
+		w := httptest.NewRecorder()
+		mw.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.True(t, s.called)
+	})
+
+	t.Run("non-POST requests pass through untouched", func(t *testing.T) {
+		s := &spy{}
+		mw := requireAuthMiddleware(newSpy(s), nil, nopLogger)
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+		mw.ServeHTTP(w, req)
+
+		assert.True(t, s.called)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+}


### PR DESCRIPTION
Spec-compliant reactive OAuth clients (OAuth 2.1 + RFC 9728 / RFC 6750) wait for an HTTP 401 with a `WWW-Authenticate` header before starting their authorization flow. The HTTP transport never emitted one — missing auth was optional at the transport, and a tool call without a PAT only failed in-band as an HTTP 200 `IsError` result. Such clients could connect and list tools but never authenticate to execute them.

## Changes

- **New HTTP middleware** (`middleware.go`), active only when `EXTERNAL_OAUTH_ISSUER` is set, gating tool-executing requests:
  - `tools/call` without a usable bearer token → HTTP 401 with `WWW-Authenticate: Bearer resource_metadata="<url>"`. The URL is derived from the request (scheme + host + RFC 9728 well-known path), reusing the same construction as the protected-resource-metadata handler — not hardcoded.
  - A failed JWT→PAT exchange (RFC 8693) is now surfaced as a 401 instead of being logged and silently treated as unauthenticated.
  - `initialize` and `tools/list` stay open so clients can connect and enumerate tools before authorizing; only `tools/call` requires auth.
- **Token resolution** (bearer extraction + optional JWT exchange) factored into `extractPAT`, shared with the non-OAuth context func, which keeps its previous behaviour. Deployments without an external issuer are unchanged.
- **Discovery endpoint** (`/.well-known/oauth-protected-resource`) and health endpoints are not wrapped by the middleware — no regression.

## Testing

Added `middleware_test.go` covering:
- Unauthenticated / invalid-JWT `tools/call` → 401 + correct `WWW-Authenticate` header
- `initialize` and `tools/list` open (no auth required)
- Valid PAT / valid JWT pass-through → 200
- HTTPS via `X-Forwarded-Proto`
- Request body preservation

`go test -race ./...`, `staticcheck .`, `go vet`, and `gofmt` all clean.

## Notes

- A valid raw PAT still works. In an OAuth deployment the bearer is a JWT validated at the exchange step, so an invalid/expired token fails the exchange and yields a 401. Translating a downstream Bitrise API 401 for an invalid raw (non-JWT) PAT into a transport 401 would require response interception and is out of scope.
- `make lint` with the pinned golangci-lint v2.6.1 panics locally because that version was built with go1.25 and cannot parse the go1.26 stdlib — environmental issue, not introduced by this change.