### PR TITLE
Add stack param to trigger_bitrise_build

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -108,6 +108,7 @@ By default, all API groups are enabled. You can specify which groups to enable u
       - `pipeline_id` (optional): The pipeline to build
       - `commit_message` (optional): The commit message for the build
       - `commit_hash` (optional): The commit hash for the build
+      - `stack` (optional): Stack to run the build on, overriding the workflow's `meta.bitrise.io.stack` for this build only (e.g. "osx-xcode-16.0.x")
       - `environments` (optional): Custom environment variables for the build (array of objects with `mapped_to`, `value`, and optional `is_expand` properties)
 
 14. `get_build`

--- a/internal/tool/builds/trigger.go
+++ b/internal/tool/builds/trigger.go
@@ -33,6 +33,9 @@ var Trigger = bitrise.Tool{
 		mcp.WithString("commit_hash",
 			mcp.Description("The commit hash for the build"),
 		),
+		mcp.WithString("stack",
+			mcp.Description("Stack to run the build on, overriding the workflow's meta.bitrise.io.stack for this build only (e.g. \"osx-xcode-16.0.x\"). Undocumented by the Bitrise API reference but honored by the trigger endpoint."),
+		),
 		mcp.WithArray("environments",
 			mcp.Description(`Custom environment variables for the build.`),
 			mcp.Items(map[string]any{
@@ -80,6 +83,9 @@ var Trigger = bitrise.Tool{
 		}
 		if v := request.GetString("commit_hash", ""); v != "" {
 			buildParams["commit_hash"] = v
+		}
+		if v := request.GetString("stack", ""); v != "" {
+			buildParams["stack"] = v
 		}
 		if v, ok := request.GetArguments()["environments"]; ok {
 			buildParams["environments"] = v

--- a/kiro-powers/bitrise-ci/POWER.md
+++ b/kiro-powers/bitrise-ci/POWER.md
@@ -104,6 +104,7 @@ The Bitrise MCP server provides 67 tools organized into the following categories
     - `workflow_id` (optional): The workflow to build
     - `commit_message` (optional): The commit message for the build
     - `commit_hash` (optional): The commit hash for the build
+    - `stack` (optional): Stack to run the build on, overriding the workflow's `meta.bitrise.io.stack` for this build only (e.g. "osx-xcode-16.0.x")
     - `environments` (optional): Custom environment variables for the build (array of objects with `mapped_to`, `value`, and optional `is_expand` properties)
 
 14. **get_build** - Get a specific build of a given app


### PR DESCRIPTION
## Summary

`trigger_bitrise_build` builds `build_params` from a hardcoded allowlist that doesn't include `stack`. Bitrise's own "Start build" UI dialog sends `stack` inside `build_params`, and it's honored by the trigger endpoint — it just isn't documented anywhere in the [public API reference](https://docs.bitrise.io/en/bitrise-ci/api/triggering-and-aborting-builds.html), which only covers `branch`, `commit_hash`, `commit_message`, `tag`, `workflow_id`, `pipeline_id`, and the PR-related fields.

Today the only way to run an existing workflow on a different stack is to add a whole wrapper workflow (`meta.bitrise.io.stack` + `before_run`) per app per stack. This param lets a caller do it per-build instead, with no `bitrise.yml` change.

This is what motivated the PR: our monorepo has many deploy workflows across several apps, and validating each one against a new Xcode edge stack currently means hand-writing a `<workflow>-Xcode-27`-style wrapper per app before the migration is even scoped. With `stack` exposed here, we can trial any existing deploy workflow on the new stack directly from a trigger call — no wrapper workflows to write, review, or eventually clean up.

## Verification

Confirmed directly against `api.bitrise.io/v0.1/apps/{slug}/builds` — the exact endpoint this tool posts to (not just the `start.json` webhook trigger endpoint, which was the first signal that led to this PR):

- Triggered a workflow (`deploy-Dx` in our monorepo) whose own `meta.bitrise.io.stack` is `osx-xcode-26.6.x`.
- Set `build_params.stack: osx-xcode-27.0.x-edge`.
- Resulting build's `stack_identifier` came back as `osx-xcode-27.0.x-edge` — the per-build override won over the workflow's static `meta`.
- Build aborted immediately after confirming; no need to let it run to completion.

`go build ./...`, `go test ./...`, and `go vet ./...` all pass.

## Changes

- `internal/tool/builds/trigger.go`: add optional `stack` param, mirroring the existing `workflow_id`/`commit_hash` handling exactly.
- `docs/tools.md`, `kiro-powers/bitrise-ci/POWER.md`: document the new param.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] Live-verified against `api.bitrise.io/v0.1` with a real build (see Verification above)

