### PR TITLE
Fix update_app documented arguments to match implementation

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -51,10 +51,10 @@ By default, all API groups are enabled. You can specify which groups to enable u
    - Update an app
    - Arguments:
      - `app_slug`: Identifier of the Bitrise app
+     - `title`: The new title of the application
+     - `default_branch`: The new default branch for the application
+     - `repository_url`: The new repository URL for the application
      - `is_public`: Whether the app's builds visibility is "public"
-     - `project_type`: Type of project
-     - `provider`: Repository provider
-     - `repo_url`: Repository URL
 
 7. `get_bitrise_yml`
    - Get the current Bitrise YML config file of a specified Bitrise app


### PR DESCRIPTION
## Summary
`docs/tools.md`'s `update_app` entry listed `project_type`, `provider`, and `repo_url` — none of which exist in `internal/tool/apps/update.go`'s tool definition. Passing them per the docs would be silently ignored. The doc also omitted the two real arguments (`title`, `default_branch`) and misnamed `repository_url` as `repo_url`.

- Removed `project_type` / `provider` (not read anywhere in the handler)
- Renamed `repo_url` → `repository_url` to match the actual parameter name
- Added `title` and `default_branch` (declared in `mcp.NewTool(...)` but undocumented)
- Kept `is_public` (functional — read directly off raw request args in the handler, though not declared in the tool schema)

Found via a docs-vs-implementation validation pass on `bitrise-io/docs`.

## Test plan
- [x] Verified against `internal/tool/apps/update.go`'s `mcp.NewTool("update_app", ...)` definition and handler
- [x] Confirmed no other file registers a competing `update_app` definition (`internal/tool/belt.go` has a single `apps.Update` reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)